### PR TITLE
Downgrade torchmetrics to 0.6.0

### DIFF
--- a/mart/configs/metric/average_precision.yaml
+++ b/mart/configs/metric/average_precision.yaml
@@ -1,11 +1,11 @@
 # @package model
 
 training_metrics:
-  _target_: torchmetrics.detection.MAP
+  _target_: torchmetrics.MAP
   compute_on_step: false
 
 validation_metrics:
-  _target_: torchmetrics.detection.MAP
+  _target_: torchmetrics.MAP
   compute_on_step: false
 
 test_metrics:
@@ -13,7 +13,7 @@ test_metrics:
   _convert_: partial
   metrics:
     map:
-      _target_: torchmetrics.detection.MAP
+      _target_: torchmetrics.MAP
       compute_on_step: false
     json:
       _target_: mart.utils.export.CocoPredictionJSON

--- a/mart/configs/metric/average_precision.yaml
+++ b/mart/configs/metric/average_precision.yaml
@@ -1,11 +1,11 @@
 # @package model
 
 training_metrics:
-  _target_: torchmetrics.MAP
+  _target_: torchmetrics.detection.MAP
   compute_on_step: false
 
 validation_metrics:
-  _target_: torchmetrics.MAP
+  _target_: torchmetrics.detection.MAP
   compute_on_step: false
 
 test_metrics:
@@ -13,7 +13,7 @@ test_metrics:
   _convert_: partial
   metrics:
     map:
-      _target_: torchmetrics.MAP
+      _target_: torchmetrics.detection.MAP
       compute_on_step: false
     json:
       _target_: mart.utils.export.CocoPredictionJSON

--- a/mart/configs/metric/average_precision.yaml
+++ b/mart/configs/metric/average_precision.yaml
@@ -1,11 +1,11 @@
 # @package model
 
 training_metrics:
-  _target_: torchmetrics.detection.mean_ap.MeanAveragePrecision
+  _target_: torchmetrics.MAP
   compute_on_step: false
 
 validation_metrics:
-  _target_: torchmetrics.detection.mean_ap.MeanAveragePrecision
+  _target_: torchmetrics.MAP
   compute_on_step: false
 
 test_metrics:
@@ -13,7 +13,7 @@ test_metrics:
   _convert_: partial
   metrics:
     map:
-      _target_: torchmetrics.detection.mean_ap.MeanAveragePrecision
+      _target_: torchmetrics.MAP
       compute_on_step: false
     json:
       _target_: mart.utils.export.CocoPredictionJSON

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -110,6 +110,7 @@ class LitModular(LightningModule):
         if self.training_metrics is not None:
             # Some models only return loss in the training mode.
             metrics = self.training_metrics.compute()
+            metrics = self.flatten_metrics(metrics)
             self.training_metrics.reset()
 
             self.log_metrics(metrics, prefix="training_metrics")
@@ -135,6 +136,7 @@ class LitModular(LightningModule):
 
     def validation_epoch_end(self, outputs):
         metrics = self.validation_metrics.compute()
+        metrics = self.flatten_metrics(metrics)
         self.validation_metrics.reset()
 
         self.log_metrics(metrics, prefix="validation_metrics")
@@ -160,6 +162,7 @@ class LitModular(LightningModule):
 
     def test_epoch_end(self, outputs):
         metrics = self.test_metrics.compute()
+        metrics = self.flatten_metrics(metrics)
         self.test_metrics.reset()
 
         self.log_metrics(metrics, prefix="test_metrics")
@@ -167,6 +170,27 @@ class LitModular(LightningModule):
     #
     # Utilities
     #
+    def flatten_metrics(self, metrics):
+        flat_metrics = {}
+
+        for k, v in metrics.items():
+            if isinstance(v, dict):
+                # recursively flatten metrics
+                v = self.flatten_metrics(v)
+                for k2, v2 in v.items():
+                    if k2 in flat_metrics:
+                        logger.warn(f"{k}/{k2} overrides existing metric!")
+
+                    flat_metrics[k2] = v2
+            else:
+                # assume raw metric
+                if k in flat_metrics:
+                    logger.warn(f"{k} overrides existing metric!")
+
+                flat_metrics[k] = v
+
+        return flat_metrics
+
     def log_metrics(self, metrics, prefix="", prog_bar=False):
         metrics_dict = {}
 

--- a/mart/utils/export.py
+++ b/mart/utils/export.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional
 
 import torch
 from torch import Tensor
-from torchmetrics.detection.mean_ap import _input_validator
 from torchmetrics.metric import Metric
 from torchvision.ops import box_convert
 
@@ -82,7 +81,6 @@ class CocoPredictionJSON(Metric):
             ValueError:
                 If any score is not type float and of length 1
         """
-        _input_validator(preds, target)
 
         for item in preds:
             self.detection_boxes.append(item["boxes"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "torch ~= 1.12.1",
   "torchvision ~= 0.13.1",
   "pytorch-lightning ~= 1.6.5",
-  "torchmetrics ~= 0.10.1",
+  "torchmetrics ~= 0.6.0",
 
   # --------- hydra --------- #
   "hydra-core ~= 1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "torch ~= 1.12.1",
   "torchvision ~= 0.13.1",
   "pytorch-lightning ~= 1.6.5",
-  "torchmetrics ~= 0.6.0",
+  "torchmetrics == 0.6.0",
 
   # --------- hydra --------- #
   "hydra-core ~= 1.2.0",


### PR DESCRIPTION
# What does this PR do?

torchmetrics > 0.6.0 is slow and this still has not been fixed in newer versions: https://github.com/Lightning-AI/metrics/issues/1024.

This should improve the performance of object detection training from 3 hours to 1 hour.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

I trained an object detector for 50 iterations:
```
$ time CUDA_VISIBLE_DEVICES=1 python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN trainer=gpu trainer.precision=16 fit=True trainer.max_steps=50 ++paths.data_dir=/raid/datasets
```

With be5dbcb, it takes:
```
244.83s user 23.34s system 129% cpu 3:26.39 total
```

With 6542ab0, it takes:
```
77.40s user 21.39s system 222% cpu 44.404 total
```

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
