### PR TITLE
Add more options to profilers

### DIFF
--- a/mart/configs/debug/profiler.yaml
+++ b/mart/configs/debug/profiler.yaml
@@ -7,6 +7,9 @@ defaults:
 
 trainer:
   max_epochs: 1
-  profiler: "simple"
-  # profiler: "advanced"
-  # profiler: "pytorch"
+  profiler:
+    _target_: pytorch_lightning.profiler.SimpleProfiler
+    # _target_: pytorch_lightning.profiler.AdvancedProfiler
+    # _target_: pytorch_lightning.profiler.PyTorchProfiler
+    dirpath: ${paths.output_dir}
+    filename: profiler_log


### PR DESCRIPTION
# What does this PR do?

Add options to the PyTorch Lightning profilers to store the profiling logs in a `.txt` file.

To use one of those profilers, you need to set the **profiler** as the **debug** options in your MART command:

```console
python -m mart experiment=COCO_TorchvisionFasterRCNN_Adv debug=profiler
```

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- See [profiling wiki page](https://github.com/IntelLabs/MART/wiki/Profiling).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
