### PR TITLE
Fix multi-GPU training

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,19 @@ python -m mart experiment=CIFAR10_RobustBench \
 
 # train on 1 GPU
 python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN \
+	task_name=1GPU_ArmoryCarlaOverObjDet_TorchvisionFasterRCNN \
 	trainer=gpu \
 	fit=true
 
 # train on multiple GPUs using Distributed Data Parallel
 python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN \
+	task_name=2GPUs_ArmoryCarlaOverObjDet_TorchvisionFasterRCNN \
+	fit=true \
 	trainer=ddp \
 	trainer.devices=2 \
-	fit=true
+	datamodule.ims_per_batch=4 \
+	model.optimizer.lr=0.025 \
+	trainer.max_steps=5244
 ```
 
 You can also install the repository as a package, then run `python -m mart` from anywhere with your own `configs` folder.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ python -m mart experiment=CIFAR10_RobustBench \
 	fit=false \
 	+trainer.limit_test_batches=1 \
 	+attack@model.modules.input_adv_test=classification_eps8_pgd10_step1
+
+# train on 1 GPU
+python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN \
+	trainer=gpu \
+	fit=true
+
+# train on multiple GPUs using Distributed Data Parallel
+python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN \
+	trainer=ddp \
+	trainer.devices=2 \
+	fit=true
 ```
 
 You can also install the repository as a package, then run `python -m mart` from anywhere with your own `configs` folder.

--- a/mart/configs/datamodule/cifar10.yaml
+++ b/mart/configs/datamodule/cifar10.yaml
@@ -41,4 +41,3 @@ test_dataset: ${.val_dataset}
 
 num_workers: 4
 collate_fn: null
-

--- a/mart/configs/datamodule/cifar10.yaml
+++ b/mart/configs/datamodule/cifar10.yaml
@@ -1,5 +1,6 @@
 # 50K Training examples and 10K validation/test shared examples.
-_target_: mart.datamodules.LitDataModule
+defaults:
+  - default.yaml
 
 train_dataset:
   _target_: torchvision.datasets.CIFAR10
@@ -41,5 +42,3 @@ test_dataset: ${.val_dataset}
 num_workers: 4
 collate_fn: null
 
-ims_per_batch: ???
-world_size: ???

--- a/mart/configs/datamodule/coco.yaml
+++ b/mart/configs/datamodule/coco.yaml
@@ -1,4 +1,5 @@
-_target_: mart.datamodules.LitDataModule
+defaults:
+  - default.yaml
 
 train_dataset:
   _target_: mart.datamodules.coco.CocoDetection
@@ -45,6 +46,3 @@ num_workers: 2
 collate_fn:
   _target_: hydra.utils.get_method
   path: mart.datamodules.coco.collate_fn
-
-ims_per_batch: ???
-world_size: ???

--- a/mart/configs/datamodule/default.yaml
+++ b/mart/configs/datamodule/default.yaml
@@ -1,0 +1,11 @@
+_target_: mart.datamodules.LitDataModule
+# _convert_: all
+
+train_dataset: ???
+val_dataset: ???
+test_dataset: ???
+
+num_workers: 0
+
+ims_per_batch: ???
+world_size: ${trainer.devices}

--- a/mart/configs/datamodule/dummy_classification.yaml
+++ b/mart/configs/datamodule/dummy_classification.yaml
@@ -1,5 +1,5 @@
-_target_: mart.datamodules.LitDataModule
-# _convert_: all
+defaults:
+  - default.yaml
 
 train_dataset:
   _target_: torchvision.datasets.FakeData
@@ -15,8 +15,3 @@ train_dataset:
 
 val_dataset: ${.train_dataset}
 test_dataset: ${.val_dataset}
-
-num_workers: 0
-
-ims_per_batch: ???
-world_size: ???

--- a/mart/configs/datamodule/imagenet.yaml
+++ b/mart/configs/datamodule/imagenet.yaml
@@ -1,5 +1,5 @@
-_target_: mart.datamodules.LitDataModule
-# _convert_: all
+defaults:
+  - default.yaml
 
 train_dataset:
   _target_: torchvision.datasets.ImageNet
@@ -32,8 +32,3 @@ val_dataset:
         scale: 255
 
 test_dataset: ${.val_dataset}
-
-num_workers: 0
-
-ims_per_batch: ???
-world_size: ???

--- a/mart/configs/experiment/CIFAR10_CNN.yaml
+++ b/mart/configs/experiment/CIFAR10_CNN.yaml
@@ -18,7 +18,6 @@ callbacks:
     mode: "max"
 
 trainer:
-  gpus: ${datamodule.world_size}
   # 50K training images, batch_size=128, drop_last, 15 epochs.
   max_steps: 5850
   precision: 32

--- a/mart/configs/experiment/COCO_TorchvisionFasterRCNN.yaml
+++ b/mart/configs/experiment/COCO_TorchvisionFasterRCNN.yaml
@@ -18,7 +18,6 @@ callbacks:
     mode: "max"
 
 trainer:
-  gpus: ${datamodule.world_size}
   # 117,266 training images, 6 epochs, batch_size=2, 351798
   max_steps: 351798
   # FIXME: "nms_kernel" not implemented for 'BFloat16', torch.ops.torchvision.nms().

--- a/mart/configs/experiment/COCO_TorchvisionRetinaNet.yaml
+++ b/mart/configs/experiment/COCO_TorchvisionRetinaNet.yaml
@@ -18,7 +18,6 @@ callbacks:
     mode: "max"
 
 trainer:
-  gpus: ${datamodule.world_size}
   # 117,266 training images, 6 epochs, batch_size=2, 351798
   max_steps: 351798
   precision: 16

--- a/mart/configs/experiment/ImageNet_Timm.yaml
+++ b/mart/configs/experiment/ImageNet_Timm.yaml
@@ -16,7 +16,6 @@ callbacks:
     monitor: "validation_metrics/acc"
 
 trainer:
-  gpus: ${datamodule.world_size}
   # 1.2M training images, 15 epochs, batch_size=128, max_steps=1.2e6*15/128=140625
   max_steps: 140625
   precision: 16

--- a/mart/configs/hydra/default.yaml
+++ b/mart/configs/hydra/default.yaml
@@ -5,6 +5,11 @@ defaults:
   - override hydra_logging: colorlog
   - override job_logging: colorlog
 
+# Since Hydra 1.2, we need to explicitly tell it to change the working directory.
+# https://hydra.cc/docs/next/upgrades/1.1_to_1.2/changes_to_job_working_dir/
+job:
+  chdir: true
+
 # output directory, generated dynamically on each run
 run:
   dir: ${paths.log_dir}/${task_name}/runs/${now:%Y-%m-%d}_${now:%H-%M-%S}

--- a/mart/configs/trainer/ddp.yaml
+++ b/mart/configs/trainer/ddp.yaml
@@ -1,11 +1,7 @@
 defaults:
   - default.yaml
 
-# use "ddp_spawn" instead of "ddp",
-# it's slower but normal "ddp" currently doesn't work ideally with hydra
-# https://github.com/facebookresearch/hydra/issues/2070
-# https://pytorch-lightning.readthedocs.io/en/latest/accelerators/gpu_intermediate.html#distributed-data-parallel-spawn
-strategy: ddp_spawn
+strategy: ddp
 
 accelerator: gpu
 devices: 4

--- a/mart/configs/trainer/ddp.yaml
+++ b/mart/configs/trainer/ddp.yaml
@@ -4,6 +4,5 @@ defaults:
 strategy: ddp
 
 accelerator: gpu
-devices: 4
 num_nodes: 1
 sync_batchnorm: True

--- a/mart/configs/trainer/ddp_sim.yaml
+++ b/mart/configs/trainer/ddp_sim.yaml
@@ -3,5 +3,4 @@ defaults:
 
 # simulate DDP on CPU, useful for debugging
 accelerator: cpu
-devices: 2
 strategy: ddp_spawn

--- a/mart/configs/trainer/default.yaml
+++ b/mart/configs/trainer/default.yaml
@@ -6,7 +6,7 @@ min_epochs: 1 # prevents early stopping
 # max_epochs: 10
 
 accelerator: cpu
-devices: ${datamodule.world_size}
+devices: 1
 
 # mixed precision for extra speed-up
 # precision: 16

--- a/mart/configs/trainer/default.yaml
+++ b/mart/configs/trainer/default.yaml
@@ -6,7 +6,7 @@ min_epochs: 1 # prevents early stopping
 # max_epochs: 10
 
 accelerator: cpu
-devices: 1
+devices: ${datamodule.world_size}
 
 # mixed precision for extra speed-up
 # precision: 16


### PR DESCRIPTION
# What does this PR do?

* Change the DDP trainer's strategy.
* Remove use of trainer's `gpus` property, since it is deprecated and was affecting the use of `devices` property.
* Update training instructions on GPUs in the `README.md` file.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Train `FasterRCNN` model with `Carla` dataset using 1 GPU:
```
python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN trainer=gpu fit=true
```
- [x] Train `FasterRCNN` model with `Carla` dataset on multiple GPUs:
```
python -m mart experiment=ArmoryCarlaOverObjDet_TorchvisionFasterRCNN trainer=ddp trainer.devices=2 fit=true
```

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
