### PR TITLE
Composable sequences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,11 @@ carla_attack: $(CARLA_OVERHEAD_DATASET_TRAIN) $(CARLA_OVERHEAD_DATASET_DEV) ## E
 	trainer=gpu \
 	fit=false \
 	model.modules.losses_and_detections.model.weights_fpath=null \
-	+attack@model.modules.input_adv_test=object_detection_mask_adversary \
-	model.modules.input_adv_test.optimizer.lr=5 \
-	model.modules.input_adv_test.max_iters=50 \
+	+attack@model.modules.input_adv=object_detection_mask_adversary \
+	model.modules.input_adv.optimizer.lr=5 \
+	model.modules.input_adv.max_iters=50 \
+	+model.test_sequence.seq001.input_adv._call_with_args_=[input,target] \
+	+model.test_sequence.seq001.input_adv.model=model \
+	+model.test_sequence.seq001.input_adv.step=step \
+	model.test_sequence.seq010.preprocessor=[input_adv] \
 	tags=["MaskPGD50_LR5"]

--- a/mart/configs/model/modular.yaml
+++ b/mart/configs/model/modular.yaml
@@ -1,8 +1,9 @@
 _target_: mart.models.LitModular
+_convert_: all
 
 modules: ???
 optimizer: ???
 
-validation_metrics: ${.training_metrics}
-# We may use different metrics in test.
-# test_metrics: ${.training_metrics}
+training_sequence: ???
+validation_sequence: ???
+test_sequence: ???

--- a/mart/configs/model/torchvision_faster_rcnn.yaml
+++ b/mart/configs/model/torchvision_faster_rcnn.yaml
@@ -13,13 +13,14 @@ training_step_log:
   ]
 
 training_sequence:
-  - input_adv_training:
-      _call_with_args_: ["input", "target"]
-      model: model
-      step: step
-  - preprocessor: ["input_adv_training"]
-  - losses_and_detections: ["preprocessor", "target"]
-  - loss:
+  seq010:
+    preprocessor: ["input"]
+
+  seq020:
+    losses_and_detections: ["preprocessor", "target"]
+
+  seq030:
+    loss:
       # Sum up the losses.
       [
         "losses_and_detections.training.loss_objectness",
@@ -27,7 +28,9 @@ training_sequence:
         "losses_and_detections.training.loss_classifier",
         "losses_and_detections.training.loss_box_reg",
       ]
-  - output:
+
+  seq040:
+    output:
       # Output all losses for logging, defined in model.training_step_log
       {
         "preds": "losses_and_detections.eval",
@@ -40,13 +43,14 @@ training_sequence:
       }
 
 validation_sequence:
-  - input_adv_validation:
-      _call_with_args_: ["input", "target"]
-      model: model
-      step: step
-  - preprocessor: ["input_adv_validation"]
-  - losses_and_detections: ["preprocessor", "target"]
-  - output:
+  seq010:
+    preprocessor: ["input"]
+
+  seq020:
+    losses_and_detections: ["preprocessor", "target"]
+
+  seq030:
+    output:
       {
         "preds": "losses_and_detections.eval",
         "target": "target",
@@ -57,13 +61,14 @@ validation_sequence:
       }
 
 test_sequence:
-  - input_adv_test:
-      _call_with_args_: ["input", "target"]
-      model: model
-      step: step
-  - preprocessor: ["input_adv_test"]
-  - losses_and_detections: ["preprocessor", "target"]
-  - output:
+  seq010:
+    preprocessor: ["input"]
+
+  seq020:
+    losses_and_detections: ["preprocessor", "target"]
+
+  seq030:
+    output:
       {
         "preds": "losses_and_detections.eval",
         "target": "target",

--- a/mart/configs/model/torchvision_object_detection.yaml
+++ b/mart/configs/model/torchvision_object_detection.yaml
@@ -2,24 +2,7 @@
 defaults:
   - modular
 
-training_step_log: ???
-
-training_sequence: ???
-
-validation_sequence: ???
-
-test_sequence: ???
-
 modules:
-  input_adv_training:
-    _target_: mart.attack.NoAdversary
-
-  input_adv_validation:
-    _target_: mart.attack.NoAdversary
-
-  input_adv_test:
-    _target_: mart.attack.NoAdversary
-
   preprocessor:
     _target_: mart.transforms.TupleTransforms
     transforms:

--- a/mart/configs/model/torchvision_retinanet.yaml
+++ b/mart/configs/model/torchvision_retinanet.yaml
@@ -6,11 +6,7 @@ defaults:
 training_step_log: ["loss_classifier", "loss_box_reg"]
 
 training_sequence:
-  - input_adv_training:
-      _call_with_args_: ["input", "target"]
-      model: model
-      step: step
-  - preprocessor: ["input_adv_training"]
+  - preprocessor: ["input"]
   - losses_and_detections: ["preprocessor", "target"]
   - loss:
       # Sum up the losses.
@@ -29,11 +25,7 @@ training_sequence:
       }
 
 validation_sequence:
-  - input_adv_validation:
-      _call_with_args_: ["input", "target"]
-      model: model
-      step: step
-  - preprocessor: ["input_adv_validation"]
+  - preprocessor: ["input"]
   - losses_and_detections: ["preprocessor", "target"]
   - output:
       {
@@ -44,11 +36,7 @@ validation_sequence:
       }
 
 test_sequence:
-  - input_adv_test:
-      _call_with_args_: ["input", "target"]
-      model: model
-      step: step
-  - preprocessor: ["input_adv_test"]
+  - preprocessor: ["input"]
   - losses_and_detections: ["preprocessor", "target"]
   - output:
       {

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -37,6 +37,14 @@ class LitModular(LightningModule):
     ):
         super().__init__()
 
+        # Convert dict sequences to list sequences by sorting keys
+        if isinstance(training_sequence, dict):
+            training_sequence = [training_sequence[key] for key in sorted(training_sequence)]
+        if isinstance(validation_sequence, dict):
+            validation_sequence = [validation_sequence[key] for key in sorted(validation_sequence)]
+        if isinstance(test_sequence, dict):
+            test_sequence = [test_sequence[key] for key in sorted(test_sequence)]
+
         # *_step() functions make some assumptions about the type of Module it can call.
         # That is, injecting a nn.Module generally won't work, so better to hardcode ModuleDict.
         # It also gets rid of an indentation level in the configs.

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 from typing import OrderedDict  # noqa: E402
 
 import torch  # noqa: E402
-from omegaconf.dictconfig import DictConfig  # noqa: E402
 
 __all__ = ["GroupNorm32", "SequentialDict", "ReturnKwargs", "CallWith", "Sum", "load_state_dict"]
 
@@ -68,14 +67,14 @@ class SequentialDict(torch.nn.ModuleDict):
 
         module_dict = OrderedDict()
         for module_info in sequence:
-            if not isinstance(module_info, DictConfig) or len(module_info) != 1:
+            if not isinstance(module_info, dict) or len(module_info) != 1:
                 raise ValueError(
-                    f"Each module config in the sequence list should be a length-one DictConfig: {module_info}"
+                    f"Each module config in the sequence list should be a length-one dict: {module_info}"
                 )
 
             module_name, module_cfg = list(module_info.items())[0]
 
-            if not isinstance(module_cfg, DictConfig):
+            if not isinstance(module_cfg, dict):
                 # We can omit the key of _call_with_args_ if it is the only config.
                 module_cfg = {"_call_with_args_": module_cfg}
 


### PR DESCRIPTION
# What does this PR do?

This PR implements composable sequences. MART currently uses lists to describe sequences, which tells MART how to execute a set of modules. Since Hydra/OmegaConf does not compose lists at all, this has led to copying and pasting of sequences and workarounds (e.g., `NoAdversary`). This PR enables sequences as described by dictionaries (which Hydra/OmegaConf can compose).

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `make test`
- [ ] `make carla_attack`

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
