### PR TITLE
Allow empty program error messages.

### DIFF
--- a/tests/helpers/run_sh_command.py
+++ b/tests/helpers/run_sh_command.py
@@ -15,5 +15,6 @@ def run_sh_command(command: List[str]):
         sh.python(command, _out=lambda log: print(log.strip()))
     except sh.ErrorReturnCode as e:
         msg = e.stderr.decode()
-    if msg:
+    # The error message could be empty.
+    if msg is not None:
         pytest.fail(msg=msg)

--- a/tests/helpers/run_sh_command.py
+++ b/tests/helpers/run_sh_command.py
@@ -10,11 +10,9 @@ if _SH_AVAILABLE:
 
 def run_sh_command(command: List[str]):
     """Default method for executing shell commands with pytest and sh package."""
-    msg = None
     try:
         sh.python(command, _out=lambda log: print(log.strip()))
     except sh.ErrorReturnCode as e:
         msg = e.stderr.decode()
-    # The error message could be empty.
-    if msg is not None:
+        # The error message could be empty.
         pytest.fail(msg=msg)


### PR DESCRIPTION
# What does this PR do?

We want `pytest` to detect non-zero return value of a program and fail a test, but the previous code will ignore the error if the message is empty. The fix allows failing a test with an empty error message.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
