### PR TITLE
Bump to 0.4.0a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mart"
-version = "0.2.0"
+version = "0.4.0a0"
 description = "Modular Adversarial Robustness Toolkit"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
# What does this PR do?

Bump the main branch to `0.4.0a0` as we have released `v0.3.0`.
