### PR TITLE
Allow adversaries to run at any layer.

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -258,37 +258,30 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 class Adversary(IterativeGenerator):
     """An adversary module which generates and applies perturbation to input."""
 
-    def __init__(self, threat_model: ThreatModel, *args, step=None, **kwargs):
+    def __init__(self, threat_model: ThreatModel, *args, **kwargs):
         """_summary_
 
         Args:
             threat_model (torch.nn.Module): A layer which injects perturbation to input, serving as the preprocessing layer to the target model.
-            step (str, optional): The name of model sequence for attack. Defaults to None.
         """
         super().__init__(*args, **kwargs)
 
         self.threat_model = threat_model
-        self.step = step
 
     def forward(
         self,
         input: Union[torch.Tensor, tuple],
         target: Union[torch.Tensor, Dict[str, Any], tuple],
         model: Optional[torch.nn.Module] = None,
-        step=None,
         **kwargs
     ):
-        # To enable adversary to run custom sequence, we prefer the step specified at Adversary's initialization.
-        step = self.step or step
-
         # Generate a perturbation only if we have a model. This will update
         # the parameters of self.perturber.
         if model is not None:
-            super().forward(input, target, model, step=step, **kwargs)
+            super().forward(input, target, model, **kwargs)
 
         # Get perturbation and apply threat model
         perturbation = self.perturber(input, target)
-        # FIXME: Remove **kwargs for threat model.
         output = self.threat_model(input, target, perturbation, **kwargs)
 
         return output

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -208,9 +208,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         if isinstance(target, torch.Tensor):
             target = target.clone()
 
-        # Make a copy of sequence, so that we can repeatedly evaluate the model here.
-        kwargs["sequence"] = kwargs["sequence"].copy()
-
         # Set model as None, because no need to update perturbation.
         # Save everything to self.outputs so that callbacks have access to them.
         model = kwargs.pop("model")

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -80,7 +80,7 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         self,
         perturber: Union[BatchPerturber, Perturber],
         optimizer: torch.optim.Optimizer,
-        max_iters: Union[int, float],
+        max_iters: int,
         gain: Gain,
         objective: Optional[Objective] = None,
         callbacks: Optional[Dict[str, Callback]] = None,
@@ -88,11 +88,11 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         """_summary_
 
         Args:
-            perturber (torch.nn.Module): _description_.
+            perturber (Union[BatchPerturber, Perturber]): _description_.
             optimizer (torch.optim.Optimizer): A PyTorch optimizer.
             max_iters (int): The max number of attack iterations.
-            gain (torch.nn.Module): An adversarial gain function, which is a differentiable estimate of adversarial objective.
-            objective (torch.nn.Module): A function for computing adversarial objective, which returns True or False.
+            gain (Gain): An adversarial gain function, which is a differentiable estimate of adversarial objective.
+            objective (Objective): A function for computing adversarial objective, which returns True or False.
             callbacks (dict): A dict of callback objects.
         """
         super().__init__()

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -164,7 +164,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         """_summary_
 
         Args:
-            input (_type_): _description_
             target (_type_): _description_
             model (_type_): _description_
         """

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -167,9 +167,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
             model (_type_): _description_
         """
 
-        # FIXME: We may get rid of this by exclusively using **kwargs.
-        # input = kwargs.pop("input")
-
         self.on_run_start(self, **kwargs)
 
         while True:

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -258,30 +258,37 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 class Adversary(IterativeGenerator):
     """An adversary module which generates and applies perturbation to input."""
 
-    def __init__(self, threat_model: ThreatModel, *args, **kwargs):
+    def __init__(self, threat_model: ThreatModel, *args, step=None, **kwargs):
         """_summary_
 
         Args:
             threat_model (torch.nn.Module): A layer which injects perturbation to input, serving as the preprocessing layer to the target model.
+            step (str, optional): The name of model sequence for attack. Defaults to None.
         """
         super().__init__(*args, **kwargs)
 
         self.threat_model = threat_model
+        self.step = step
 
     def forward(
         self,
         input: Union[torch.Tensor, tuple],
         target: Union[torch.Tensor, Dict[str, Any], tuple],
         model: Optional[torch.nn.Module] = None,
+        step=None,
         **kwargs
     ):
+        # To enable adversary to run custom sequence, we prefer the step specified at Adversary's initialization.
+        step = self.step or step
+
         # Generate a perturbation only if we have a model. This will update
         # the parameters of self.perturber.
         if model is not None:
-            super().forward(input, target, model, **kwargs)
+            super().forward(input, target, model, step=step, **kwargs)
 
         # Get perturbation and apply threat model
         perturbation = self.perturber(input, target)
+        # FIXME: Remove **kwargs for threat model.
         output = self.threat_model(input, target, perturbation, **kwargs)
 
         return output

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -210,7 +210,13 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
                         model=model,
                         **kwargs,
                     )
-                    self.advance()
+                    self.advance(
+                        adversary=self,
+                        input=input,
+                        target=target,
+                        model=model,
+                        **kwargs,
+                    )
                     self.on_advance_end(
                         adversary=self,
                         input=input,

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -179,9 +179,9 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     @torch.autocast("cpu", enabled=False)
     def forward(
         self,
+        *,
         input: Union[torch.Tensor, tuple],
         target: Union[torch.Tensor, Dict[str, Any], tuple],
-        *,
         model: torch.nn.Module,
         **kwargs,
     ):

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -196,7 +196,7 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
                 self.on_examine_start(
                     adversary=self, input=input, target=target, model=model, **kwargs
                 )
-                self.examine(adversary=self, input=input, target=target, model=model, **kwargs)
+                self.examine(input=input, target=target, model=model, **kwargs)
                 self.on_examine_end(
                     adversary=self, input=input, target=target, model=model, **kwargs
                 )
@@ -211,7 +211,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
                         **kwargs,
                     )
                     self.advance(
-                        adversary=self,
                         input=input,
                         target=target,
                         model=model,
@@ -240,7 +239,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     @torch.inference_mode(False)
     def examine(
         self,
-        adversary: Optional[torch.nn.Module] = None,
         input: Optional[Union[torch.Tensor, tuple]] = None,
         target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]] = None,
         model: Optional[torch.nn.Module] = None,
@@ -279,7 +277,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     @torch.inference_mode(False)
     def advance(
         self,
-        adversary: Optional[torch.nn.Module] = None,
         input: Optional[Union[torch.Tensor, tuple]] = None,
         target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]] = None,
         model: Optional[torch.nn.Module] = None,

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -136,10 +136,10 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def on_run_start(
         self,
         *,
-        adversary: Optional[torch.nn.Module],
-        input: Optional[Union[torch.Tensor, tuple]],
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
-        model: Optional[torch.nn.Module],
+        adversary: torch.nn.Module,
+        input: Union[torch.Tensor, tuple],
+        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        model: torch.nn.Module,
         **kwargs,
     ):
         super().on_run_start(
@@ -162,10 +162,10 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def on_run_end(
         self,
         *,
-        adversary: Optional[torch.nn.Module],
-        input: Optional[Union[torch.Tensor, tuple]],
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
-        model: Optional[torch.nn.Module],
+        adversary: torch.nn.Module,
+        input: Union[torch.Tensor, tuple],
+        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        model: torch.nn.Module,
         **kwargs,
     ):
         super().on_run_end(adversary=adversary, input=input, target=target, model=model, **kwargs)
@@ -182,7 +182,7 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         input: Union[torch.Tensor, tuple],
         target: Union[torch.Tensor, Dict[str, Any], tuple],
         *,
-        model: Optional[torch.nn.Module],
+        model: torch.nn.Module,
         **kwargs,
     ):
         """_summary_
@@ -243,9 +243,9 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def examine(
         self,
         *,
-        input: Optional[Union[torch.Tensor, tuple]],
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
-        model: Optional[torch.nn.Module],
+        input: Union[torch.Tensor, tuple],
+        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        model: torch.nn.Module,
         **kwargs,
     ):
         """Examine current perturbation, update self.gain and self.found."""
@@ -282,9 +282,9 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def advance(
         self,
         *,
-        input: Optional[Union[torch.Tensor, tuple]],
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
-        model: Optional[torch.nn.Module],
+        input: Union[torch.Tensor, tuple],
+        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        model: torch.nn.Module,
         **kwargs,
     ):
         """Run one attack iteration."""

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -5,8 +5,10 @@
 # agreement between Intel Corporation and you.
 #
 
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import torch
 
@@ -78,12 +80,12 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 
     def __init__(
         self,
-        perturber: Union[BatchPerturber, Perturber],
+        perturber: BatchPerturber | Perturber,
         optimizer: torch.optim.Optimizer,
         max_iters: int,
         gain: Gain,
-        objective: Optional[Objective] = None,
-        callbacks: Optional[Dict[str, Callback]] = None,
+        objective: Objective | None = None,
+        callbacks: dict[str, Callback] | None = None,
     ):
         """_summary_
 
@@ -137,8 +139,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         self,
         *,
         adversary: torch.nn.Module,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -163,8 +165,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         self,
         *,
         adversary: torch.nn.Module,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -180,8 +182,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def forward(
         self,
         *,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -243,8 +245,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def examine(
         self,
         *,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -282,8 +284,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     def advance(
         self,
         *,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -312,9 +314,9 @@ class Adversary(IterativeGenerator):
 
     def forward(
         self,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
-        model: Optional[torch.nn.Module] = None,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         # Generate a perturbation only if we have a model. This will update
@@ -333,9 +335,9 @@ class Adversary(IterativeGenerator):
 class NoAdversary(torch.nn.Module):
     def forward(
         self,
-        input: Union[torch.Tensor, tuple],
-        target: Union[torch.Tensor, Dict[str, Any], tuple],
-        model: Optional[torch.nn.Module] = None,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         return input

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -135,10 +135,11 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 
     def on_run_start(
         self,
-        adversary: Optional[torch.nn.Module] = None,
-        input: Optional[Union[torch.Tensor, tuple]] = None,
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]] = None,
-        model: Optional[torch.nn.Module] = None,
+        *,
+        adversary: Optional[torch.nn.Module],
+        input: Optional[Union[torch.Tensor, tuple]],
+        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
+        model: Optional[torch.nn.Module],
         **kwargs,
     ):
         super().on_run_start(
@@ -160,10 +161,11 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 
     def on_run_end(
         self,
-        adversary: Optional[torch.nn.Module] = None,
-        input: Optional[Union[torch.Tensor, tuple]] = None,
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]] = None,
-        model: Optional[torch.nn.Module] = None,
+        *,
+        adversary: Optional[torch.nn.Module],
+        input: Optional[Union[torch.Tensor, tuple]],
+        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
+        model: Optional[torch.nn.Module],
         **kwargs,
     ):
         super().on_run_end(adversary=adversary, input=input, target=target, model=model, **kwargs)
@@ -179,7 +181,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         self,
         input: Union[torch.Tensor, tuple],
         target: Union[torch.Tensor, Dict[str, Any], tuple],
-        model: Optional[torch.nn.Module] = None,
+        *,
+        model: Optional[torch.nn.Module],
         **kwargs,
     ):
         """_summary_
@@ -239,9 +242,10 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     @torch.inference_mode(False)
     def examine(
         self,
-        input: Optional[Union[torch.Tensor, tuple]] = None,
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]] = None,
-        model: Optional[torch.nn.Module] = None,
+        *,
+        input: Optional[Union[torch.Tensor, tuple]],
+        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
+        model: Optional[torch.nn.Module],
         **kwargs,
     ):
         """Examine current perturbation, update self.gain and self.found."""
@@ -277,9 +281,10 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
     @torch.inference_mode(False)
     def advance(
         self,
-        input: Optional[Union[torch.Tensor, tuple]] = None,
-        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]] = None,
-        model: Optional[torch.nn.Module] = None,
+        *,
+        input: Optional[Union[torch.Tensor, tuple]],
+        target: Optional[Union[torch.Tensor, Dict[str, Any], tuple]],
+        model: Optional[torch.nn.Module],
         **kwargs,
     ):
         """Run one attack iteration."""

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -80,6 +80,7 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 
     def __init__(
         self,
+        *,
         perturber: BatchPerturber | Perturber,
         optimizer: torch.optim.Optimizer,
         max_iters: int,
@@ -302,13 +303,13 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
 class Adversary(IterativeGenerator):
     """An adversary module which generates and applies perturbation to input."""
 
-    def __init__(self, threat_model: ThreatModel, *args, **kwargs):
+    def __init__(self, *, threat_model: ThreatModel, **kwargs):
         """_summary_
 
         Args:
             threat_model (torch.nn.Module): A layer which injects perturbation to input, serving as the preprocessing layer to the target model.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.threat_model = threat_model
 

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -279,13 +279,14 @@ class Adversary(IterativeGenerator):
     ):
         # Backward compatible: earlier configs have two unnamed arguments [input, target].
         kwargs["input"] = input
+
+        # The benign input to an adversary is not necessarily the model input.
+        # It could be activations of other modules.
         self.benign_input = kwargs[self.benign_input_key]
 
         # Generate a perturbation only if we have a model. This will update
         # the parameters of self.perturber.
         if model is not None:
-            # The benign input to an adversary is not necessarily the model input.
-            # It could be activations of other modules.
             super().forward(target, model, **kwargs)
 
         # Get perturbation and apply threat model

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -91,12 +91,12 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         """_summary_
 
         Args:
-            perturber (BatchPerturber | Perturber): _description_.
+            perturber (BatchPerturber | Perturber): A module that stores perturbations.
             optimizer (torch.optim.Optimizer): A PyTorch optimizer.
             max_iters (int): The max number of attack iterations.
             gain (Gain): An adversarial gain function, which is a differentiable estimate of adversarial objective.
-            objective (Objective | None): A function for computing adversarial objective, which returns True or False.
-            callbacks (dict[str, Callback] | None): A dict of callback objects.
+            objective (Objective | None): A function for computing adversarial objective, which returns True or False. Optional.
+            callbacks (dict[str, Callback] | None): A dictionary of callback objects. Optional.
         """
         super().__init__()
 
@@ -188,12 +188,6 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         model: torch.nn.Module,
         **kwargs,
     ):
-        """_summary_
-
-        Args:
-            target (_type_): _description_
-            model (_type_): _description_
-        """
 
         self.on_run_start(adversary=self, input=input, target=target, model=model, **kwargs)
 
@@ -307,7 +301,7 @@ class Adversary(IterativeGenerator):
         """_summary_
 
         Args:
-            threat_model (torch.nn.Module): A layer which injects perturbation to input, serving as the preprocessing layer to the target model.
+            threat_model (ThreatModel): A layer which injects perturbation to input, serving as the preprocessing layer to the target model.
         """
         super().__init__(**kwargs)
 

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -90,12 +90,12 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         """_summary_
 
         Args:
-            perturber (Union[BatchPerturber, Perturber]): _description_.
+            perturber (BatchPerturber | Perturber): _description_.
             optimizer (torch.optim.Optimizer): A PyTorch optimizer.
             max_iters (int): The max number of attack iterations.
             gain (Gain): An adversarial gain function, which is a differentiable estimate of adversarial objective.
-            objective (Objective): A function for computing adversarial objective, which returns True or False.
-            callbacks (dict): A dict of callback objects.
+            objective (Objective | None): A function for computing adversarial objective, which returns True or False.
+            callbacks (dict[str, Callback] | None): A dict of callback objects.
         """
         super().__init__()
 

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -29,27 +29,27 @@ class AdversaryCallbackHookMixin(Callback):
         for _name, callback in self.callbacks.items():
             # FIXME: Skip incomplete callback instance.
             # Give access of self to callbacks by `adversary=self`.
-            callback.on_run_start(adversary=self, **kwargs)
+            callback.on_run_start(**kwargs)
 
     def on_examine_start(self, **kwargs) -> None:
         for _name, callback in self.callbacks.items():
-            callback.on_examine_start(adversary=self, **kwargs)
+            callback.on_examine_start(**kwargs)
 
     def on_examine_end(self, **kwargs) -> None:
         for _name, callback in self.callbacks.items():
-            callback.on_examine_end(adversary=self, **kwargs)
+            callback.on_examine_end(**kwargs)
 
     def on_advance_start(self, **kwargs) -> None:
         for _name, callback in self.callbacks.items():
-            callback.on_advance_start(adversary=self, **kwargs)
+            callback.on_advance_start(**kwargs)
 
     def on_advance_end(self, **kwargs) -> None:
         for _name, callback in self.callbacks.items():
-            callback.on_advance_end(adversary=self, **kwargs)
+            callback.on_advance_end(**kwargs)
 
     def on_run_end(self, **kwargs) -> None:
         for _name, callback in self.callbacks.items():
-            callback.on_run_end(adversary=self, **kwargs)
+            callback.on_run_end(**kwargs)
 
 
 class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
@@ -175,19 +175,27 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
             model (_type_): _description_
         """
 
-        self.on_run_start(input=input, target=target, model=model, **kwargs)
+        self.on_run_start(adversary=self, input=input, target=target, model=model, **kwargs)
 
         while True:
             try:
-                self.on_examine_start(input=input, target=target, model=model, **kwargs)
-                self.examine(input=input, target=target, model=model, **kwargs)
-                self.on_examine_end(input=input, target=target, model=model, **kwargs)
+                self.on_examine_start(
+                    adversary=self, input=input, target=target, model=model, **kwargs
+                )
+                self.examine(adversary=self, input=input, target=target, model=model, **kwargs)
+                self.on_examine_end(
+                    adversary=self, input=input, target=target, model=model, **kwargs
+                )
 
                 # Check the done condition here, so that every update of perturbation is examined.
                 if not self.done:
-                    self.on_advance_start(input=input, target=target, model=model, **kwargs)
+                    self.on_advance_start(
+                        adversary=self, input=input, target=target, model=model, **kwargs
+                    )
                     self.advance()
-                    self.on_advance_end(input=input, target=target, model=model, **kwargs)
+                    self.on_advance_end(
+                        adversary=self, input=input, target=target, model=model, **kwargs
+                    )
                     # Update cur_iter at the end so that all hooks get the correct cur_iter.
                     self.cur_iter += 1
                 else:
@@ -195,7 +203,7 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
             except StopIteration:
                 break
 
-        self.on_run_end(input=input, target=target, model=model, **kwargs)
+        self.on_run_end(adversary=self, input=input, target=target, model=model, **kwargs)
 
     # Make sure we can do autograd.
     # Earlier Pytorch Lightning uses no_grad(), but later PL uses inference_mode():

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -8,9 +8,7 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Any, Dict, Union
-
-import torch
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..adversary import Adversary
@@ -24,9 +22,6 @@ class Callback(abc.ABC):
     def on_run_start(
         self,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        model: torch.nn.Module,
         **kwargs,
     ):
         pass
@@ -34,9 +29,6 @@ class Callback(abc.ABC):
     def on_examine_start(
         self,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        model: torch.nn.Module,
         **kwargs,
     ):
         pass
@@ -44,9 +36,6 @@ class Callback(abc.ABC):
     def on_examine_end(
         self,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        model: torch.nn.Module,
         **kwargs,
     ):
         pass
@@ -54,9 +43,6 @@ class Callback(abc.ABC):
     def on_advance_start(
         self,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        model: torch.nn.Module,
         **kwargs,
     ):
         pass
@@ -64,9 +50,6 @@ class Callback(abc.ABC):
     def on_advance_end(
         self,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        model: torch.nn.Module,
         **kwargs,
     ):
         pass
@@ -74,9 +57,6 @@ class Callback(abc.ABC):
     def on_run_end(
         self,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        model: torch.nn.Module,
         **kwargs,
     ):
         pass

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -21,42 +21,36 @@ class Callback(abc.ABC):
 
     def on_run_start(
         self,
-        adversary: Adversary,
         **kwargs,
     ):
         pass
 
     def on_examine_start(
         self,
-        adversary: Adversary,
         **kwargs,
     ):
         pass
 
     def on_examine_end(
         self,
-        adversary: Adversary,
         **kwargs,
     ):
         pass
 
     def on_advance_start(
         self,
-        adversary: Adversary,
         **kwargs,
     ):
         pass
 
     def on_advance_end(
         self,
-        adversary: Adversary,
         **kwargs,
     ):
         pass
 
     def on_run_end(
         self,
-        adversary: Adversary,
         **kwargs,
     ):
         pass

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -23,60 +23,60 @@ class Callback(abc.ABC):
 
     def on_run_start(
         self,
-        adversary: Adversary = None,
-        input: torch.Tensor | tuple = None,
-        target: torch.Tensor | dict[str, Any] | tuple = None,
-        model: torch.nn.Module = None,
+        adversary: Adversary | None = None,
+        input: torch.Tensor | tuple | None = None,
+        target: torch.Tensor | dict[str, Any] | tuple | None = None,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         pass
 
     def on_examine_start(
         self,
-        adversary: Adversary = None,
-        input: torch.Tensor | tuple = None,
-        target: torch.Tensor | dict[str, Any] | tuple = None,
-        model: torch.nn.Module = None,
+        adversary: Adversary | None = None,
+        input: torch.Tensor | tuple | None = None,
+        target: torch.Tensor | dict[str, Any] | tuple | None = None,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         pass
 
     def on_examine_end(
         self,
-        adversary: Adversary = None,
-        input: torch.Tensor | tuple = None,
-        target: torch.Tensor | dict[str, Any] | tuple = None,
-        model: torch.nn.Module = None,
+        adversary: Adversary | None = None,
+        input: torch.Tensor | tuple | None = None,
+        target: torch.Tensor | dict[str, Any] | tuple | None = None,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         pass
 
     def on_advance_start(
         self,
-        adversary: Adversary = None,
-        input: torch.Tensor | tuple = None,
-        target: torch.Tensor | dict[str, Any] | tuple = None,
-        model: torch.nn.Module = None,
+        adversary: Adversary | None = None,
+        input: torch.Tensor | tuple | None = None,
+        target: torch.Tensor | dict[str, Any] | tuple | None = None,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         pass
 
     def on_advance_end(
         self,
-        adversary: Adversary = None,
-        input: torch.Tensor | tuple = None,
-        target: torch.Tensor | dict[str, Any] | tuple = None,
-        model: torch.nn.Module = None,
+        adversary: Adversary | None = None,
+        input: torch.Tensor | tuple | None = None,
+        target: torch.Tensor | dict[str, Any] | tuple | None = None,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         pass
 
     def on_run_end(
         self,
-        adversary: Adversary = None,
-        input: torch.Tensor | tuple = None,
-        target: torch.Tensor | dict[str, Any] | tuple = None,
-        model: torch.nn.Module = None,
+        adversary: Adversary | None = None,
+        input: torch.Tensor | tuple | None = None,
+        target: torch.Tensor | dict[str, Any] | tuple | None = None,
+        model: torch.nn.Module | None = None,
         **kwargs,
     ):
         pass

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -23,60 +23,66 @@ class Callback(abc.ABC):
 
     def on_run_start(
         self,
-        adversary: Adversary | None = None,
-        input: torch.Tensor | tuple | None = None,
-        target: torch.Tensor | dict[str, Any] | tuple | None = None,
-        model: torch.nn.Module | None = None,
+        *,
+        adversary: Adversary,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module,
         **kwargs,
     ):
         pass
 
     def on_examine_start(
         self,
-        adversary: Adversary | None = None,
-        input: torch.Tensor | tuple | None = None,
-        target: torch.Tensor | dict[str, Any] | tuple | None = None,
-        model: torch.nn.Module | None = None,
+        *,
+        adversary: Adversary,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module,
         **kwargs,
     ):
         pass
 
     def on_examine_end(
         self,
-        adversary: Adversary | None = None,
-        input: torch.Tensor | tuple | None = None,
-        target: torch.Tensor | dict[str, Any] | tuple | None = None,
-        model: torch.nn.Module | None = None,
+        *,
+        adversary: Adversary,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module,
         **kwargs,
     ):
         pass
 
     def on_advance_start(
         self,
-        adversary: Adversary | None = None,
-        input: torch.Tensor | tuple | None = None,
-        target: torch.Tensor | dict[str, Any] | tuple | None = None,
-        model: torch.nn.Module | None = None,
+        *,
+        adversary: Adversary,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module,
         **kwargs,
     ):
         pass
 
     def on_advance_end(
         self,
-        adversary: Adversary | None = None,
-        input: torch.Tensor | tuple | None = None,
-        target: torch.Tensor | dict[str, Any] | tuple | None = None,
-        model: torch.nn.Module | None = None,
+        *,
+        adversary: Adversary,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module,
         **kwargs,
     ):
         pass
 
     def on_run_end(
         self,
-        adversary: Adversary | None = None,
-        input: torch.Tensor | tuple | None = None,
-        target: torch.Tensor | dict[str, Any] | tuple | None = None,
-        model: torch.nn.Module | None = None,
+        *,
+        adversary: Adversary,
+        input: torch.Tensor | tuple,
+        target: torch.Tensor | dict[str, Any] | tuple,
+        model: torch.nn.Module,
         **kwargs,
     ):
         pass

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -8,7 +8,9 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import torch
 
 if TYPE_CHECKING:
     from ..adversary import Adversary
@@ -21,36 +23,60 @@ class Callback(abc.ABC):
 
     def on_run_start(
         self,
+        adversary: Adversary = None,
+        input: torch.Tensor | tuple = None,
+        target: torch.Tensor | dict[str, Any] | tuple = None,
+        model: torch.nn.Module = None,
         **kwargs,
     ):
         pass
 
     def on_examine_start(
         self,
+        adversary: Adversary = None,
+        input: torch.Tensor | tuple = None,
+        target: torch.Tensor | dict[str, Any] | tuple = None,
+        model: torch.nn.Module = None,
         **kwargs,
     ):
         pass
 
     def on_examine_end(
         self,
+        adversary: Adversary = None,
+        input: torch.Tensor | tuple = None,
+        target: torch.Tensor | dict[str, Any] | tuple = None,
+        model: torch.nn.Module = None,
         **kwargs,
     ):
         pass
 
     def on_advance_start(
         self,
+        adversary: Adversary = None,
+        input: torch.Tensor | tuple = None,
+        target: torch.Tensor | dict[str, Any] | tuple = None,
+        model: torch.nn.Module = None,
         **kwargs,
     ):
         pass
 
     def on_advance_end(
         self,
+        adversary: Adversary = None,
+        input: torch.Tensor | tuple = None,
+        target: torch.Tensor | dict[str, Any] | tuple = None,
+        model: torch.nn.Module = None,
         **kwargs,
     ):
         pass
 
     def on_run_end(
         self,
+        adversary: Adversary = None,
+        input: torch.Tensor | tuple = None,
+        target: torch.Tensor | dict[str, Any] | tuple = None,
+        model: torch.nn.Module = None,
         **kwargs,
     ):
         pass

--- a/mart/attack/callbacks/eval_mode.py
+++ b/mart/attack/callbacks/eval_mode.py
@@ -16,14 +16,12 @@ class AttackInEvalMode(Callback):
     def __init__(self):
         self.training_mode_status = None
 
-    def on_run_start(self, **kwargs):
-        model = kwargs["model"]
+    def on_run_start(self, model=None, **kwargs):
         self.training_mode_status = model.training
         model.train(False)
 
-    def on_run_end(self, **kwargs):
+    def on_run_end(self, model=None, **kwargs):
         assert self.training_mode_status is not None
 
         # Resume the previous training status of the model.
-        model = kwargs["model"]
         model.train(self.training_mode_status)

--- a/mart/attack/callbacks/eval_mode.py
+++ b/mart/attack/callbacks/eval_mode.py
@@ -16,12 +16,14 @@ class AttackInEvalMode(Callback):
     def __init__(self):
         self.training_mode_status = None
 
-    def on_run_start(self, adversary, input, target, model, **kwargs):
+    def on_run_start(self, adversary, **kwargs):
+        model = kwargs["model"]
         self.training_mode_status = model.training
         model.train(False)
 
-    def on_run_end(self, adversary, input, target, model, **kwargs):
+    def on_run_end(self, adversary, **kwargs):
         assert self.training_mode_status is not None
 
         # Resume the previous training status of the model.
+        model = kwargs["model"]
         model.train(self.training_mode_status)

--- a/mart/attack/callbacks/eval_mode.py
+++ b/mart/attack/callbacks/eval_mode.py
@@ -16,11 +16,11 @@ class AttackInEvalMode(Callback):
     def __init__(self):
         self.training_mode_status = None
 
-    def on_run_start(self, model=None, **kwargs):
+    def on_run_start(self, *, model, **kwargs):
         self.training_mode_status = model.training
         model.train(False)
 
-    def on_run_end(self, model=None, **kwargs):
+    def on_run_end(self, *, model, **kwargs):
         assert self.training_mode_status is not None
 
         # Resume the previous training status of the model.

--- a/mart/attack/callbacks/eval_mode.py
+++ b/mart/attack/callbacks/eval_mode.py
@@ -16,12 +16,12 @@ class AttackInEvalMode(Callback):
     def __init__(self):
         self.training_mode_status = None
 
-    def on_run_start(self, adversary, **kwargs):
+    def on_run_start(self, **kwargs):
         model = kwargs["model"]
         self.training_mode_status = model.training
         model.train(False)
 
-    def on_run_end(self, adversary, **kwargs):
+    def on_run_end(self, **kwargs):
         assert self.training_mode_status is not None
 
         # Resume the previous training status of the model.

--- a/mart/attack/callbacks/no_grad_mode.py
+++ b/mart/attack/callbacks/no_grad_mode.py
@@ -16,10 +16,12 @@ class ModelParamsNoGrad(Callback):
     This callback should not change the result. Don't use unless an attack runs faster.
     """
 
-    def on_run_start(self, adversary, input, target, model, **kwargs):
+    def on_run_start(self, adversary, **kwargs):
+        model = kwargs["model"]
         for param in model.parameters():
             param.requires_grad_(False)
 
-    def on_run_end(self, adversary, input, target, model, **kwargs):
+    def on_run_end(self, adversary, **kwargs):
+        model = kwargs["model"]
         for param in model.parameters():
             param.requires_grad_(True)

--- a/mart/attack/callbacks/no_grad_mode.py
+++ b/mart/attack/callbacks/no_grad_mode.py
@@ -16,12 +16,12 @@ class ModelParamsNoGrad(Callback):
     This callback should not change the result. Don't use unless an attack runs faster.
     """
 
-    def on_run_start(self, adversary, **kwargs):
+    def on_run_start(self, **kwargs):
         model = kwargs["model"]
         for param in model.parameters():
             param.requires_grad_(False)
 
-    def on_run_end(self, adversary, **kwargs):
+    def on_run_end(self, **kwargs):
         model = kwargs["model"]
         for param in model.parameters():
             param.requires_grad_(True)

--- a/mart/attack/callbacks/no_grad_mode.py
+++ b/mart/attack/callbacks/no_grad_mode.py
@@ -16,10 +16,10 @@ class ModelParamsNoGrad(Callback):
     This callback should not change the result. Don't use unless an attack runs faster.
     """
 
-    def on_run_start(self, model=None, **kwargs):
+    def on_run_start(self, *, model, **kwargs):
         for param in model.parameters():
             param.requires_grad_(False)
 
-    def on_run_end(self, model=None, **kwargs):
+    def on_run_end(self, *, model, **kwargs):
         for param in model.parameters():
             param.requires_grad_(True)

--- a/mart/attack/callbacks/no_grad_mode.py
+++ b/mart/attack/callbacks/no_grad_mode.py
@@ -16,12 +16,10 @@ class ModelParamsNoGrad(Callback):
     This callback should not change the result. Don't use unless an attack runs faster.
     """
 
-    def on_run_start(self, **kwargs):
-        model = kwargs["model"]
+    def on_run_start(self, model=None, **kwargs):
         for param in model.parameters():
             param.requires_grad_(False)
 
-    def on_run_end(self, **kwargs):
-        model = kwargs["model"]
+    def on_run_end(self, model=None, **kwargs):
         for param in model.parameters():
             param.requires_grad_(True)

--- a/mart/attack/callbacks/progress_bar.py
+++ b/mart/attack/callbacks/progress_bar.py
@@ -15,10 +15,10 @@ __all__ = ["ProgressBar"]
 class ProgressBar(Callback):
     """Display progress bar of attack iterations with the gain value."""
 
-    def on_run_start(self, adversary=None, **kwargs):
+    def on_run_start(self, *, adversary, **kwargs):
         self.pbar = tqdm.tqdm(total=adversary.max_iters, leave=False, desc="Attack", unit="iter")
 
-    def on_examine_end(self, adversary=None, **kwargs):
+    def on_examine_end(self, *, adversary, **kwargs):
         input = kwargs["input"]
         msg = ""
         if hasattr(adversary, "found"):

--- a/mart/attack/callbacks/progress_bar.py
+++ b/mart/attack/callbacks/progress_bar.py
@@ -15,10 +15,10 @@ __all__ = ["ProgressBar"]
 class ProgressBar(Callback):
     """Display progress bar of attack iterations with the gain value."""
 
-    def on_run_start(self, adversary, **kwargs):
+    def on_run_start(self, adversary=None, **kwargs):
         self.pbar = tqdm.tqdm(total=adversary.max_iters, leave=False, desc="Attack", unit="iter")
 
-    def on_examine_end(self, adversary, **kwargs):
+    def on_examine_end(self, adversary=None, **kwargs):
         input = kwargs["input"]
         msg = ""
         if hasattr(adversary, "found"):

--- a/mart/attack/callbacks/progress_bar.py
+++ b/mart/attack/callbacks/progress_bar.py
@@ -30,6 +30,6 @@ class ProgressBar(Callback):
         self.pbar.set_description(msg)
         self.pbar.update(1)
 
-    def on_run_end(self, adversary, **kwargs):
+    def on_run_end(self, **kwargs):
         self.pbar.close()
         del self.pbar

--- a/mart/attack/callbacks/progress_bar.py
+++ b/mart/attack/callbacks/progress_bar.py
@@ -15,10 +15,11 @@ __all__ = ["ProgressBar"]
 class ProgressBar(Callback):
     """Display progress bar of attack iterations with the gain value."""
 
-    def on_run_start(self, adversary, input, target, model, **kwargs):
+    def on_run_start(self, adversary, **kwargs):
         self.pbar = tqdm.tqdm(total=adversary.max_iters, leave=False, desc="Attack", unit="iter")
 
-    def on_examine_end(self, adversary, input, target, model, **kwargs):
+    def on_examine_end(self, adversary, **kwargs):
+        input = kwargs["input"]
         msg = ""
         if hasattr(adversary, "found"):
             # there is no adversary.found if adversary.objective_fn() is not defined.
@@ -29,6 +30,6 @@ class ProgressBar(Callback):
         self.pbar.set_description(msg)
         self.pbar.update(1)
 
-    def on_run_end(self, adversary, input, target, model, **kwargs):
+    def on_run_end(self, adversary, **kwargs):
         self.pbar.close()
         del self.pbar

--- a/mart/attack/callbacks/progress_bar.py
+++ b/mart/attack/callbacks/progress_bar.py
@@ -18,8 +18,7 @@ class ProgressBar(Callback):
     def on_run_start(self, *, adversary, **kwargs):
         self.pbar = tqdm.tqdm(total=adversary.max_iters, leave=False, desc="Attack", unit="iter")
 
-    def on_examine_end(self, *, adversary, **kwargs):
-        input = kwargs["input"]
+    def on_examine_end(self, *, input, adversary, **kwargs):
         msg = ""
         if hasattr(adversary, "found"):
             # there is no adversary.found if adversary.objective_fn() is not defined.

--- a/mart/attack/callbacks/visualizer.py
+++ b/mart/attack/callbacks/visualizer.py
@@ -26,12 +26,8 @@ class PerturbedImageVisualizer(Callback):
         if not os.path.isdir(self.folder):
             os.makedirs(self.folder)
 
-    def on_run_end(self, adversary, **kwargs):
-        input = kwargs.pop("input")
-        target = kwargs.pop("target")
-        kwargs.pop("model")
-
-        adv_input = adversary(input, target, model=None, **kwargs)
+    def on_run_end(self, adversary=None, input=None, target=None, model=None, **kwargs):
+        adv_input = adversary(input=input, target=target, model=None, **kwargs)
 
         for img, tgt in zip(adv_input, target):
             fname = tgt["file_name"]

--- a/mart/attack/callbacks/visualizer.py
+++ b/mart/attack/callbacks/visualizer.py
@@ -26,7 +26,7 @@ class PerturbedImageVisualizer(Callback):
         if not os.path.isdir(self.folder):
             os.makedirs(self.folder)
 
-    def on_run_end(self, adversary=None, input=None, target=None, model=None, **kwargs):
+    def on_run_end(self, *, adversary, input, target, model, **kwargs):
         adv_input = adversary(input=input, target=target, model=None, **kwargs)
 
         for img, tgt in zip(adv_input, target):

--- a/mart/attack/callbacks/visualizer.py
+++ b/mart/attack/callbacks/visualizer.py
@@ -7,7 +7,6 @@
 
 import os
 
-import torch
 from torchvision.transforms import ToPILImage
 
 from .base import Callback
@@ -27,7 +26,11 @@ class PerturbedImageVisualizer(Callback):
         if not os.path.isdir(self.folder):
             os.makedirs(self.folder)
 
-    def on_run_end(self, adversary, input, target, model, **kwargs):
+    def on_run_end(self, adversary, **kwargs):
+        input = kwargs.pop("input")
+        target = kwargs.pop("target")
+        kwargs.pop("model")
+
         adv_input = adversary(input, target, model=None, **kwargs)
 
         for img, tgt in zip(adv_input, target):

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -34,6 +34,7 @@ class LitModular(LightningModule):
         test_metrics=None,
         weights_fpath=None,
         strict=True,
+        other_sequences=None,
     ):
         super().__init__()
 
@@ -43,22 +44,21 @@ class LitModular(LightningModule):
         # assert validation_sequence is not None
         # assert test_sequence is not None
 
-        # Convert dict sequences to list sequences by sorting keys
-        if isinstance(training_sequence, dict):
-            training_sequence = [training_sequence[key] for key in sorted(training_sequence)]
-        if isinstance(validation_sequence, dict):
-            validation_sequence = [validation_sequence[key] for key in sorted(validation_sequence)]
-        if isinstance(test_sequence, dict):
-            test_sequence = [test_sequence[key] for key in sorted(test_sequence)]
-
         # *_step() functions make some assumptions about the type of Module it can call.
         # That is, injecting a nn.Module generally won't work, so better to hardcode SequentialDict.
         # It also gets rid of an indentation level in the configs.
-        sequences = {
-            "training": training_sequence,
-            "validation": validation_sequence,
-            "test": test_sequence,
-        }
+
+        sequences = other_sequences or {}
+        sequences["training"] = training_sequence
+        sequences["validation"] = validation_sequence
+        sequences["test"] = test_sequence
+
+        # Convert dict sequences to list sequences by sorting keys
+        for name in sequences:
+            seq = sequences[name]
+            if isinstance(seq, dict):
+                sequences[name] = [seq[key] for key in sorted(seq)]
+
         self.model = SequentialDict(modules, sequences)
 
         if weights_fpath is not None:

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -34,7 +34,6 @@ class LitModular(LightningModule):
         test_metrics=None,
         weights_fpath=None,
         strict=True,
-        other_sequences=None,
     ):
         super().__init__()
 
@@ -44,21 +43,22 @@ class LitModular(LightningModule):
         # assert validation_sequence is not None
         # assert test_sequence is not None
 
+        # Convert dict sequences to list sequences by sorting keys
+        if isinstance(training_sequence, dict):
+            training_sequence = [training_sequence[key] for key in sorted(training_sequence)]
+        if isinstance(validation_sequence, dict):
+            validation_sequence = [validation_sequence[key] for key in sorted(validation_sequence)]
+        if isinstance(test_sequence, dict):
+            test_sequence = [test_sequence[key] for key in sorted(test_sequence)]
+
         # *_step() functions make some assumptions about the type of Module it can call.
         # That is, injecting a nn.Module generally won't work, so better to hardcode SequentialDict.
         # It also gets rid of an indentation level in the configs.
-
-        sequences = other_sequences or {}
-        sequences["training"] = training_sequence
-        sequences["validation"] = validation_sequence
-        sequences["test"] = test_sequence
-
-        # Convert dict sequences to list sequences by sorting keys
-        for name in sequences:
-            seq = sequences[name]
-            if isinstance(seq, dict):
-                sequences[name] = [seq[key] for key in sorted(seq)]
-
+        sequences = {
+            "training": training_sequence,
+            "validation": validation_sequence,
+            "test": test_sequence,
+        }
         self.model = SequentialDict(modules, sequences)
 
         if weights_fpath is not None:

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -100,6 +100,9 @@ class SequentialDict(torch.nn.ModuleDict):
         else:
             sequence = kwargs["sequence"]
 
+        # Make a copy of sequence, because it will be destructed in the while loop.
+        sequence = sequence.copy()
+
         while len(sequence) > 0:
             # Don't pop the first element yet, because it may be used to re-evaluate the model.
             key, module = next(iter(sequence.items()))

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -73,7 +73,6 @@ class SequentialDict(torch.nn.ModuleDict):
                 )
 
             module_name, module_cfg = list(module_info.items())[0]
-            module = self[module_name]
 
             if not isinstance(module_cfg, dict):
                 # We can omit the key of _call_with_args_ if it is the only config.
@@ -81,18 +80,15 @@ class SequentialDict(torch.nn.ModuleDict):
 
             # The return name could be different from module_name when a module is used more than once.
             return_name = module_cfg.pop("_name_", module_name)
+            # The module would be called with these *args.
+            arg_keys = module_cfg.pop("_call_with_args_", None)
+            # The module would return a dictionary with these keys instead of a tuple.
+            return_keys = module_cfg.pop("_return_as_dict", None)
+            # The module would be called with these **kwargs.
+            kwarg_keys = module_cfg
 
-            # A module can be configured to receive specific *args and **kwargs.
-            # If not configured, it receives everything in **kwargs.
-            if len(module_cfg) > 0:
-                # The module would be called with these *args.
-                arg_keys = module_cfg.pop("_call_with_args_", None)
-                # The module would return a dictionary with these keys instead of a tuple.
-                return_keys = module_cfg.pop("_return_as_dict", None)
-                # The module would be called with these **kwargs.
-                kwarg_keys = module_cfg
-
-                module = CallWith(module, arg_keys, kwarg_keys, return_keys)
+            module = self[module_name]
+            module = CallWith(module, arg_keys, kwarg_keys, return_keys)
             module_dict[return_name] = module
         return module_dict
 

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -73,6 +73,7 @@ class SequentialDict(torch.nn.ModuleDict):
                 )
 
             module_name, module_cfg = list(module_info.items())[0]
+            module = self[module_name]
 
             if not isinstance(module_cfg, dict):
                 # We can omit the key of _call_with_args_ if it is the only config.
@@ -80,15 +81,18 @@ class SequentialDict(torch.nn.ModuleDict):
 
             # The return name could be different from module_name when a module is used more than once.
             return_name = module_cfg.pop("_name_", module_name)
-            # The module would be called with these *args.
-            arg_keys = module_cfg.pop("_call_with_args_", None)
-            # The module would return a dictionary with these keys instead of a tuple.
-            return_keys = module_cfg.pop("_return_as_dict", None)
-            # The module would be called with these **kwargs.
-            kwarg_keys = module_cfg
 
-            module = self[module_name]
-            module = CallWith(module, arg_keys, kwarg_keys, return_keys)
+            # A module can be configured to receive specific *args and **kwargs.
+            # If not configured, it receives everything in **kwargs.
+            if len(module_cfg) > 0:
+                # The module would be called with these *args.
+                arg_keys = module_cfg.pop("_call_with_args_", None)
+                # The module would return a dictionary with these keys instead of a tuple.
+                return_keys = module_cfg.pop("_return_as_dict", None)
+                # The module would be called with these **kwargs.
+                kwarg_keys = module_cfg
+
+                module = CallWith(module, arg_keys, kwarg_keys, return_keys)
             module_dict[return_name] = module
         return module_dict
 

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -92,13 +92,11 @@ class SequentialDict(torch.nn.ModuleDict):
             module_dict[return_name] = module
         return module_dict
 
-    def forward(self, step=None, **kwargs):
+    def forward(self, step=None, sequence=None, **kwargs):
         # Try to fetch the customized architectural graph.
-        if "sequence" not in kwargs:
-            # Backward compatible. We may get rid of step in the future.
+        # Backward compatible. We may get rid of step in the future.
+        if sequence is None:
             sequence = self._sequences[step]
-        else:
-            sequence = kwargs["sequence"]
 
         # Make a copy of sequence, because it will be destructed in the while loop.
         sequence = sequence.copy()
@@ -106,9 +104,8 @@ class SequentialDict(torch.nn.ModuleDict):
         while len(sequence) > 0:
             # Don't pop the first element yet, because it may be used to re-evaluate the model.
             key, module = next(iter(sequence.items()))
-            kwargs["sequence"] = sequence
 
-            output = module(step=step, **kwargs)
+            output = module(step=step, sequence=sequence, **kwargs)
 
             if key in kwargs:
                 logger.warn(f"Module {module} replaces kwargs key {key}!")

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -28,7 +28,8 @@ def test_visualizer_run_end(input_data, target_data, perturbation, tmp_path):
     adversary = Mock(spec=Adversary, side_effect=perturb)
 
     visualizer = PerturbedImageVisualizer(folder)
-    visualizer.on_run_end(adversary, input_list, target_list, model)
+    kwargs = {"input": input_list, "target": target_list, "model": model}
+    visualizer.on_run_end(adversary, **kwargs)
 
     # verify that the visualizer created the JPG file
     expected_output_path = folder / target_data["file_name"]

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -28,8 +28,7 @@ def test_visualizer_run_end(input_data, target_data, perturbation, tmp_path):
     adversary = Mock(spec=Adversary, side_effect=perturb)
 
     visualizer = PerturbedImageVisualizer(folder)
-    kwargs = {"adversary": adversary, "input": input_list, "target": target_list, "model": model}
-    visualizer.on_run_end(**kwargs)
+    visualizer.on_run_end(adversary=adversary, input=input_list, target=target_list, model=model)
 
     # verify that the visualizer created the JPG file
     expected_output_path = folder / target_data["file_name"]

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -28,8 +28,8 @@ def test_visualizer_run_end(input_data, target_data, perturbation, tmp_path):
     adversary = Mock(spec=Adversary, side_effect=perturb)
 
     visualizer = PerturbedImageVisualizer(folder)
-    kwargs = {"input": input_list, "target": target_list, "model": model}
-    visualizer.on_run_end(adversary, **kwargs)
+    kwargs = {"adversary": adversary, "input": input_list, "target": target_list, "model": model}
+    visualizer.on_run_end(**kwargs)
 
     # verify that the visualizer created the JPG file
     expected_output_path = folder / target_data["file_name"]


### PR DESCRIPTION
# What does this PR do?

We initially assumed an adversary module (e.g. `input_adv_test`) would be the first layer of a model. But we try to loose this assumption so that we can perform data transformation in a model before attack.

This PR allows an adversary module to be placed in any layer of a model, by including `sequence` of current and remaining modules in `**kwargs`.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
