### PR TITLE
Configuring optimization hyper-params in Perturber

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -159,7 +159,7 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         self.perturber(input, target)
 
         # param_groups with learning rate and other optim params.
-        param_groups = self.perturber.parameters_optim()
+        param_groups = self.perturber.parameter_groups()
 
         self.opt = self.optimizer_fn(param_groups)
 

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -158,13 +158,8 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         # FIXME: Perturbers can just use on_run_start/on_run_end to initialize
         self.perturber(input, target)
 
-        # Split param groups by input elements, so that we can schedule optimizers individually.
-        if hasattr(self.perturber, "parameters_optim"):
-            # param_groups with learning rate and other optim params.
-            param_groups = self.perturber.parameters_optim()
-        else:
-            # Backward compatibility.
-            param_groups = [{"params": [param]} for param in self.perturber.parameters()]
+        # param_groups with learning rate and other optim params.
+        param_groups = self.perturber.parameters_optim()
 
         self.opt = self.optimizer_fn(param_groups)
 

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -159,7 +159,13 @@ class IterativeGenerator(AdversaryCallbackHookMixin, torch.nn.Module):
         self.perturber(input, target)
 
         # Split param groups by input elements, so that we can schedule optimizers individually.
-        param_groups = [{"params": [param]} for param in self.perturber.parameters()]
+        if hasattr(self.perturber, "parameters_optim"):
+            # param_groups with learning rate and other optim params.
+            param_groups = self.perturber.parameters_optim()
+        else:
+            # Backward compatibility.
+            param_groups = [{"params": [param]} for param in self.perturber.parameters()]
+
         self.opt = self.optimizer_fn(param_groups)
 
     def on_run_end(

--- a/mart/attack/perturber/batch.py
+++ b/mart/attack/perturber/batch.py
@@ -46,7 +46,7 @@ class BatchPerturber(Callback, torch.nn.Module):
     def parameter_groups(self):
         """Return parameters along with optim parameters."""
         params = []
-        for _, perturber in self.perturbers.items():
+        for perturber in self.perturbers.values():
             params += perturber.parameter_groups()
         return params
 

--- a/mart/attack/perturber/batch.py
+++ b/mart/attack/perturber/batch.py
@@ -43,6 +43,13 @@ class BatchPerturber(Callback, torch.nn.Module):
 
         self.perturbers = torch.nn.ModuleDict()
 
+    def parameters_optim(self):
+        """Return parameters along with optim parameters."""
+        params = []
+        for _, perturber in self.perturbers.items():
+            params += perturber.parameters_optim()
+        return params
+
     def on_run_start(self, adversary, input, target, model, **kwargs):
         # Remove old perturbers
         # FIXME: Can we do this in on_run_end instead?

--- a/mart/attack/perturber/batch.py
+++ b/mart/attack/perturber/batch.py
@@ -43,11 +43,11 @@ class BatchPerturber(Callback, torch.nn.Module):
 
         self.perturbers = torch.nn.ModuleDict()
 
-    def parameters_optim(self):
+    def parameter_groups(self):
         """Return parameters along with optim parameters."""
         params = []
         for _, perturber in self.perturbers.items():
-            params += perturber.parameters_optim()
+            params += perturber.parameter_groups()
         return params
 
     def on_run_start(self, adversary, input, target, model, **kwargs):

--- a/mart/attack/perturber/perturber.py
+++ b/mart/attack/perturber/perturber.py
@@ -59,10 +59,10 @@ class Perturber(torch.nn.modules.lazy.LazyModuleMixin, torch.nn.Module):
         if projector is not None:
             self.register_forward_pre_hook(projector_wrapper)
 
-    def parameters_optim(self):
+    def parameter_groups(self):
         """Return parameters along with the pre-defined optimization parameters.
 
-        Example: `{"params": perturbation, "lr":0.1, "momentum": 0.9}`
+        Example: `[{"params": perturbation, "lr":0.1, "momentum": 0.9}]`
         """
         if "params" in self.optim_params:
             raise ValueError(

--- a/mart/attack/perturber/perturber.py
+++ b/mart/attack/perturber/perturber.py
@@ -64,6 +64,11 @@ class Perturber(torch.nn.modules.lazy.LazyModuleMixin, torch.nn.Module):
 
         Example: `{"params": perturbation, "lr":0.1, "momentum": 0.9}`
         """
+        if "params" in self.optim_params:
+            raise ValueError(
+                'Optimization parameters should not include "params" which will override the actual parameters to be optimized. '
+            )
+
         return [{"params": self.perturbation} | self.optim_params]
 
     def initialize_parameters(

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -69,7 +69,6 @@ def test_adversary_with_model(input_data, target_data, perturbation):
 
     output_data = adversary(input_data, target_data, model=model)
 
-    parameters.assert_called_once()
     optimizer.assert_called_once()
     # max_iters+1 because Adversary examines one last time
     assert gain.call_count == max_iters + 1

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -56,8 +56,8 @@ def test_adversary(input_data, target_data, perturbation):
 def test_adversary_with_model(input_data, target_data, perturbation):
     threat_model = mart.attack.threat_model.Additive()
     initializer = Mock()
-    parameters = Mock(return_value=[])
-    perturber = Mock(return_value=perturbation, parameters=parameters)
+    parameter_groups = Mock(return_value=[])
+    perturber = Mock(return_value=perturbation, parameter_groups=parameter_groups)
     optimizer = Mock()
     max_iters = 3
     model = Mock(return_value={})
@@ -69,6 +69,7 @@ def test_adversary_with_model(input_data, target_data, perturbation):
 
     output_data = adversary(input_data, target_data, model=model)
 
+    parameter_groups.assert_called_once()
     optimizer.assert_called_once()
     # max_iters+1 because Adversary examines one last time
     assert gain.call_count == max_iters + 1


### PR DESCRIPTION
# What does this PR do?

This PR enables configuring perturbation-wise hyper-params in attack optimization, such as learning rate, momentum, etc.

The main changes include
* Add support to `**optim_params` in `Perturber`.
* `Adversary` can fetch parameters and their optimization hyper-params by calling `Perturber.parameter_groups()`.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
