### PR TITLE
Allow modules to skip CallWith

### DIFF
--- a/mart/configs/experiment/CIFAR10_CNN_Adv.yaml
+++ b/mart/configs/experiment/CIFAR10_CNN_Adv.yaml
@@ -10,22 +10,14 @@ tags: ["adv", "fat"]
 
 model:
   training_sequence:
-    seq005:
-      input_adv_training:
-        _call_with_args_: ["input", "target"]
-        model: model
-        step: step
+    seq005: input_adv_training
 
     seq010:
       preprocessor:
         _call_with_args_: ["input_adv_training"]
 
   test_sequence:
-    seq005:
-      input_adv_test:
-        _call_with_args_: ["input", "target"]
-        model: model
-        step: step
+    seq005: input_adv_test
 
     seq010:
       preprocessor: ["input_adv_test"]

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -66,6 +66,10 @@ class SequentialDict(torch.nn.ModuleDict):
 
         module_dict = OrderedDict()
         for module_info in sequence:
+            # Treat strings as modules that don't require CallWith
+            if isinstance(module_info, str):
+                module_info = {module_info: {}}
+
             if not isinstance(module_info, dict) or len(module_info) != 1:
                 raise ValueError(
                     f"Each module config in the sequence list should be a length-one dict: {module_info}"
@@ -87,7 +91,11 @@ class SequentialDict(torch.nn.ModuleDict):
             kwarg_keys = module_cfg
 
             module = self[module_name]
-            module = CallWith(module, arg_keys, kwarg_keys, return_keys)
+
+            # Add CallWith to module if we have enough parameters
+            if arg_keys is not None or len(kwarg_keys) > 0 or return_keys is not None:
+                module = CallWith(module, arg_keys, kwarg_keys, return_keys)
+
             module_dict[return_name] = module
         return module_dict
 
@@ -153,7 +161,11 @@ class CallWith(torch.nn.Module):
         selected_args = [kwargs[key] for key in arg_keys[len(args) :]]
         selected_kwargs = {key: kwargs[val] for key, val in kwarg_keys.items()}
 
-        ret = self.module(*args, *selected_args, **selected_kwargs)
+        try:
+            ret = self.module(*args, *selected_args, **selected_kwargs)
+        except TypeError:
+            # FIXME: Add better error message
+            raise
 
         if self.return_keys:
             if not isinstance(ret, tuple):


### PR DESCRIPTION
# What does this PR do?

Modules we write do not need to use `CallWith` since we control the code. This PR enables configuration to bypass `CallWith`.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `make test`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
