### PR TITLE
Decorate initializers `__call__` with `torch.no_grad` instead of using `tensor.data`

### DIFF
--- a/mart/attack/initializer.py
+++ b/mart/attack/initializer.py
@@ -15,6 +15,7 @@ __all__ = ["Initializer"]
 class Initializer(abc.ABC):
     """Initializer base class."""
 
+    @torch.no_grad()
     @abc.abstractmethod
     def __call__(self, perturbation: torch.Tensor) -> None:
         pass
@@ -24,6 +25,7 @@ class Constant(Initializer):
     def __init__(self, constant: Optional[Union[int, float]] = 0):
         self.constant = constant
 
+    @torch.no_grad()
     def __call__(self, perturbation: torch.Tensor) -> None:
         torch.nn.init.constant_(perturbation, self.constant)
 
@@ -33,6 +35,7 @@ class Uniform(Initializer):
         self.min = min
         self.max = max
 
+    @torch.no_grad()
     def __call__(self, perturbation: torch.Tensor) -> None:
         torch.nn.init.uniform_(perturbation, self.min, self.max)
 
@@ -42,10 +45,11 @@ class UniformLp(Initializer):
         self.eps = eps
         self.p = p
 
+    @torch.no_grad()
     def __call__(self, perturbation: torch.Tensor) -> None:
         torch.nn.init.uniform_(perturbation, -self.eps, self.eps)
         # TODO: make sure the first dim is the batch dim.
         if self.p is not torch.inf:
             # We don't do tensor.renorm_() because the first dim is not the batch dim.
-            pert_norm = perturbation.data.norm(p=self.p)
-            perturbation.data.mul_(self.eps / pert_norm)
+            pert_norm = perturbation.norm(p=self.p)
+            perturbation.mul_(self.eps / pert_norm)


### PR DESCRIPTION
# What does this PR do?

This PR marks all initializers with @torch.no_grad in their __call__ methods instead of work with `tensor.data`. This makes it impossible to incorrectly mess with the gradient.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `make test`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
