### PR TITLE
Decorate projectors `__call__` with `torch.no_grad` instead of using `tensor.data`

### DIFF
--- a/mart/attack/perturber/perturber.py
+++ b/mart/attack/perturber/perturber.py
@@ -55,7 +55,7 @@ class Perturber(Callback, torch.nn.Module):
                 raise ValueError("Perturbation must be initialized")
 
             input, target = args
-            return projector(perturber_module.perturbation.data, input, target)
+            return projector(perturber_module.perturbation, input, target)
 
         # Will be called before forward() is called.
         if projector is not None:

--- a/mart/attack/projector.py
+++ b/mart/attack/projector.py
@@ -15,7 +15,7 @@ __all__ = ["Projector"]
 class Projector(abc.ABC):
     """A projector modifies nn.Parameter's data."""
 
-    @abc.abstractmethod
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,
@@ -31,6 +31,7 @@ class Compose(Projector):
     def __init__(self, projectors: List[Projector]):
         self.projectors = projectors
 
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,
@@ -58,6 +59,7 @@ class Range(Projector):
         self.min = min
         self.max = max
 
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,
@@ -90,6 +92,7 @@ class RangeAdditive(Projector):
         self.min = min
         self.max = max
 
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,
@@ -120,6 +123,7 @@ class Lp(Projector):
         self.p = p
         self.eps = eps
 
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,
@@ -146,6 +150,7 @@ class LinfAdditiveRange(Projector):
         self.min = min
         self.max = max
 
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,
@@ -159,6 +164,7 @@ class LinfAdditiveRange(Projector):
 
 
 class Mask(Projector):
+    @torch.no_grad()
     def __call__(
         self,
         tensor: torch.Tensor,


### PR DESCRIPTION
# What does this PR do?

This PR marks all projectors with @torch.no_grad in their call methods instead of work with tensor.data. This makes it impossible to incorrectly mess with the gradient.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `make test`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
