### PR TITLE
Make IterativeGenerator a Trainer

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -21,7 +21,7 @@ from .perturber import BatchPerturber, Perturber
 __all__ = ["Adversary", "Attacker"]
 
 
-class AdversaryCallbackHookMixin(Callback):
+class AttackerCallbackHookMixin(Callback):
     """Define event hooks in the Adversary Loop for callbacks."""
 
     callbacks = {}
@@ -54,7 +54,7 @@ class AdversaryCallbackHookMixin(Callback):
             callback.on_run_end(**kwargs)
 
 
-class Attacker(AdversaryCallbackHookMixin, torch.nn.Module):
+class Attacker(AttackerCallbackHookMixin, torch.nn.Module):
     """The attack optimization loop.
 
     This class implements the following loop structure:


### PR DESCRIPTION
# What does this PR do?

This PR exposes IterativeGenerator as a Trainer, named `Attacker`, that we inject into an Adversary. This PR also raises of the question of whether `Composer` should be a component of the `Attacker` or the `Adversary`.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `make test`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
