### PR TITLE
Make Projector batch aware

### DIFF
--- a/mart/attack/perturber/perturber.py
+++ b/mart/attack/perturber/perturber.py
@@ -55,7 +55,7 @@ class Perturber(Callback, torch.nn.Module):
                 raise ValueError("Perturbation must be initialized")
 
             input, target = args
-            return projector(perturber_module.perturbation, input, target)
+            return projector(perturber_module.perturbation, input=input, target=target)
 
         # Will be called before forward() is called.
         if projector is not None:

--- a/tests/test_projector.py
+++ b/tests/test_projector.py
@@ -36,7 +36,7 @@ def test_range_projector_repr():
 @pytest.mark.parametrize("max", [10, 100, 110])
 def test_range_projector(quantize, min, max, input_data, target_data, perturbation):
     projector = Range(quantize, min, max)
-    projector(perturbation, input_data, target_data)
+    projector(perturbation, input=input_data, target=target_data)
 
     assert torch.max(perturbation) <= max
     assert torch.min(perturbation) >= min
@@ -61,7 +61,7 @@ def test_range_additive_projector(quantize, min, max, input_data, target_data, p
     expected_perturbation = torch.clone(perturbation)
 
     projector = RangeAdditive(quantize, min, max)
-    projector(perturbation, input_data, target_data)
+    projector(perturbation, input=input_data, target=target_data)
 
     # modify expected_perturbation
     if quantize:
@@ -78,7 +78,7 @@ def test_lp_projector(eps, p, input_data, target_data, perturbation):
     expected_perturbation = torch.clone(perturbation)
 
     projector = Lp(eps, p)
-    projector(perturbation, input_data, target_data)
+    projector(perturbation, input=input_data, target=target_data)
 
     # modify expected_perturbation
     pert_norm = expected_perturbation.norm(p=p)
@@ -95,7 +95,7 @@ def test_linf_additive_range_projector(min, max, eps, input_data, target_data, p
     expected_perturbation = torch.clone(perturbation)
 
     projector = LinfAdditiveRange(eps, min, max)
-    projector(perturbation, input_data, target_data)
+    projector(perturbation, input=input_data, target=target_data)
 
     # get expected result
     eps_min = (input_data - eps).clamp(min, max) - input_data
@@ -117,7 +117,7 @@ def test_mask_projector(input_data, target_data, perturbation):
     expected_perturbation = torch.clone(perturbation)
 
     projector = Mask()
-    projector(perturbation, input_data, target_data)
+    projector(perturbation, input=input_data, target=target_data)
 
     # get expected output
     expected_perturbation.mul_(target_data["perturbable_mask"])
@@ -156,7 +156,7 @@ def test_compose(input_data, target_data):
     compose = Compose(projectors)
     tensor = Mock()
     tensor.norm.return_value = 10
-    compose(tensor, input_data, target_data)
+    compose(tensor, input=input_data, target=target_data)
 
     # RangeProjector, RangeAdditiveProjector, and LinfAdditiveRangeProjector calls `clamp_`
     assert tensor.clamp_.call_count == 3


### PR DESCRIPTION
# What does this PR do?

The current `Projector` is not batch/tuple aware, which is necessary for attacks on datasets where input images have different shapes (e.g., COCO). This PR makes it so.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `make test`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
