### PR TITLE
Remove BatchComposer in favor of batch-aware Composer

### DIFF
--- a/mart/configs/attack/composer/batch_additive.yaml
+++ b/mart/configs/attack/composer/batch_additive.yaml
@@ -1,5 +1,0 @@
-defaults:
-  - /attack/composer@composer: additive
-
-_target_: mart.attack.BatchComposer
-composer: ???

--- a/mart/configs/attack/composer/batch_overlay.yaml
+++ b/mart/configs/attack/composer/batch_overlay.yaml
@@ -1,5 +1,0 @@
-defaults:
-  - /attack/composer@composer: overlay
-
-_target_: mart.attack.BatchComposer
-composer: ???

--- a/mart/configs/attack/object_detection_mask_adversary.yaml
+++ b/mart/configs/attack/object_detection_mask_adversary.yaml
@@ -7,7 +7,7 @@ defaults:
   - callbacks: [progress_bar, image_visualizer]
   - objective: zero_ap
   - gain: rcnn_training_loss
-  - composer: batch_overlay
+  - composer: overlay
   - enforcer: batch
   - enforcer/constraints: [mask, pixel_range]
 


### PR DESCRIPTION
# What does this PR do?

Instead of wrapping existing Composers in a `BatchComposer` wrapper, we can just make the `Composer` base class batch/tuple-aware. This simplifies things.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `make test`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
