### PR TITLE
Make Enforcer modality-aware

### DIFF
--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -137,5 +137,6 @@ class ModalityEnforcer(Enforcer):
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self._enforce(input_adv_i, input=input_i, target=target_i)
 
+    @torch.no_grad()
     def __call__(self, input_adv, *, input, target, **kwargs):
         self._enforce(input_adv, input=input, target=target)

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -98,23 +98,36 @@ class Enforcer:
     def __init__(self, **modality_constraints: dict[str, dict[str, Constraint]]) -> None:
         self.modality_constraints = modality_constraints
 
-    def _enforce(self, input_adv, *, input, target, modality="constraints"):
-        # Set modality="constraints" by default, so that it is backward compatible with existing configs without modalities.
+    @torch.no_grad()
+    def _enforce(
+        self,
+        input_adv: torch.Tensor,
+        *,
+        input: torch.Tensor,
+        target: torch.Tensor | dict[str, Any],
+        modality: str,
+    ):
+        for constraint in self.modality_constraints[modality].values():
+            constraint(input_adv, input=input, target=target)
+
+    def __call__(
+        self,
+        input_adv: torch.Tensor | tuple[torch.Tensor] | dict[str, torch.Tensor],
+        *,
+        input: torch.Tensor | tuple[torch.Tensor] | dict[str, torch.Tensor],
+        target: torch.Tensor | dict[str, Any],
+        modality: str = "constraints",
+        **kwargs,
+    ):
         if isinstance(input_adv, torch.Tensor):
             # Finally we can verify constraints on tensor, per its modality.
-            for constraint in self.modality_constraints[modality].values():
-                constraint(input_adv, input=input, target=target)
+            # Set modality="constraints" by default, so that it is backward compatible with existing configs without modalities.
+            self._enforce(input_adv, input=input, target=target, modality=modality)
         elif isinstance(input_adv, dict):
             # The dict input has modalities specified in keys, passing them recursively.
             for modality in input_adv:
-                self._enforce(
-                    input_adv[modality], input=input[modality], target=target, modality=modality
-                )
+                self(input_adv[modality], input=input[modality], target=target, modality=modality)
         elif isinstance(input_adv, list) or isinstance(input_adv, tuple):
             # The list or tuple input is a collection of sub-input.
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
-                self._enforce(input_adv_i, input=input_i, target=target_i)
-
-    @torch.no_grad()
-    def __call__(self, input_adv, *, input, target, **kwargs):
-        self._enforce(input_adv, input=input, target=target)
+                self(input_adv_i, input=input_i, target=target_i)

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -128,6 +128,6 @@ class Enforcer:
             for modality in input_adv:
                 self(input_adv[modality], input=input[modality], target=target, modality=modality)
         elif isinstance(input_adv, (list, tuple)):
-            # The list or tuple input is a collection of sub-input.
+            # The list or tuple input is a collection of sub-input and sub-target.
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self(input_adv_i, input=input_i, target=target_i)

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -99,7 +99,7 @@ class Enforcer:
         self.modality_constraints = modality_constraints
 
     def _enforce(self, input_adv, *, input, target, modality="constraints"):
-        # Set modality="constraitns" by default, so that it is backward compatible with existing configs without modalities.
+        # Set modality="constraints" by default, so that it is backward compatible with existing configs without modalities.
         if isinstance(input_adv, torch.Tensor):
             for constraint in self.modality_constraints[modality].values():
                 constraint(input_adv, input=input, target=target)

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -127,7 +127,7 @@ class Enforcer:
             # The dict input has modalities specified in keys, passing them recursively.
             for modality in input_adv:
                 self(input_adv[modality], input=input[modality], target=target, modality=modality)
-        elif isinstance(input_adv, list) or isinstance(input_adv, tuple):
+        elif isinstance(input_adv, (list, tuple)):
             # The list or tuple input is a collection of sub-input.
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self(input_adv_i, input=input_i, target=target_i)

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -119,6 +119,8 @@ class Enforcer:
         modality: str = "constraints",
         **kwargs,
     ):
+        assert type(input_adv) == type(input)
+
         if isinstance(input_adv, torch.Tensor):
             # Finally we can verify constraints on tensor, per its modality.
             # Set modality="constraints" by default, so that it is backward compatible with existing configs without modalities.
@@ -131,3 +133,5 @@ class Enforcer:
             # The list or tuple input is a collection of sub-input and sub-target.
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self(input_adv_i, input=input_i, target=target_i)
+        else:
+            raise ValueError(f"Unsupported data type of input_adv: {type(input_adv)}.")

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -26,6 +26,7 @@ class Constraint(abc.ABC):
         input: torch.Tensor | tuple,
         target: torch.Tensor | dict[str, Any] | tuple,
     ) -> None:
+        # TODO: Now we can get rid of this.
         if isinstance(input_adv, tuple):
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self.verify(input_adv_i, input=input_i, target=target_i)
@@ -117,6 +118,10 @@ class Enforcer:
 
 class ModalityEnforcer(Enforcer):
     def __init__(self, **modality_constraints: dict[str, dict[str, Constraint]]) -> None:
+        # Backward compatible for existing configs without modalities.
+        if len(modality_constraints) == 1 and "constraints" in modality_constraints:
+            modality_constraints = {"default": modality_constraints}
+
         self.modality_constraints = modality_constraints
 
     def _enforce(self, input_adv, *, input, target, modality="default"):

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import torch
 
-__all__ = ["ModalityEnforcer"]
+__all__ = ["Enforcer"]
 
 
 class ConstraintViolated(Exception):
@@ -100,23 +100,6 @@ class Mask(Constraint):
 
 
 class Enforcer:
-    def __init__(self, constraints: dict[str, Constraint] | None = None) -> None:
-        self.constraints = constraints or {}
-
-    @torch.no_grad()
-    def __call__(
-        self,
-        input_adv: torch.Tensor | tuple,
-        *,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
-        **kwargs,
-    ) -> None:
-        for constraint in self.constraints.values():
-            constraint(input_adv, input=input, target=target)
-
-
-class ModalityEnforcer(Enforcer):
     def __init__(self, **modality_constraints: dict[str, dict[str, Constraint]]) -> None:
         # Backward compatible for existing configs without modalities.
         if len(modality_constraints) == 1 and "constraints" in modality_constraints:

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -21,10 +21,10 @@ class ConstraintViolated(Exception):
 class Constraint(abc.ABC):
     def __call__(
         self,
-        input_adv: torch.Tensor | tuple,
+        input_adv: torch.Tensor,
         *,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor,
+        target: torch.Tensor | dict[str, Any],
     ) -> None:
         self.verify(input_adv, input=input, target=target)
 

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -101,13 +101,10 @@ class Mask(Constraint):
 
 class Enforcer:
     def __init__(self, **modality_constraints: dict[str, dict[str, Constraint]]) -> None:
-        # Backward compatible for existing configs without modalities.
-        if len(modality_constraints) == 1 and "constraints" in modality_constraints:
-            modality_constraints = {"default": modality_constraints}
-
         self.modality_constraints = modality_constraints
 
-    def _enforce(self, input_adv, *, input, target, modality="default"):
+    def _enforce(self, input_adv, *, input, target, modality="constraints"):
+        # Set modality="constraitns" by default, so that it is backward compatible with existing configs without modalities.
         if isinstance(input_adv, torch.Tensor):
             for constraint in self.modality_constraints[modality].values():
                 constraint(input_adv, input=input, target=target)

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -112,9 +112,9 @@ class Enforcer:
 
     def __call__(
         self,
-        input_adv: torch.Tensor | tuple[torch.Tensor] | dict[str, torch.Tensor],
+        input_adv: torch.Tensor | tuple | list[torch.Tensor] | dict[str, torch.Tensor],
         *,
-        input: torch.Tensor | tuple[torch.Tensor] | dict[str, torch.Tensor],
+        input: torch.Tensor | tuple | list[torch.Tensor] | dict[str, torch.Tensor],
         target: torch.Tensor | dict[str, Any],
         modality: str = "constraints",
         **kwargs,

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -101,14 +101,17 @@ class Enforcer:
     def _enforce(self, input_adv, *, input, target, modality="constraints"):
         # Set modality="constraints" by default, so that it is backward compatible with existing configs without modalities.
         if isinstance(input_adv, torch.Tensor):
+            # Finally we can verify constraints on tensor, per its modality.
             for constraint in self.modality_constraints[modality].values():
                 constraint(input_adv, input=input, target=target)
         elif isinstance(input_adv, dict):
+            # The dict input has modalities specified in keys, passing them recursively.
             for modality in input_adv:
                 self._enforce(
                     input_adv[modality], input=input[modality], target=target, modality=modality
                 )
         elif isinstance(input_adv, list) or isinstance(input_adv, tuple):
+            # The list or tuple input is a collection of sub-input.
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self._enforce(input_adv_i, input=input_i, target=target_i)
 

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -26,12 +26,7 @@ class Constraint(abc.ABC):
         input: torch.Tensor | tuple,
         target: torch.Tensor | dict[str, Any] | tuple,
     ) -> None:
-        # TODO: Now we can get rid of this.
-        if isinstance(input_adv, tuple):
-            for input_adv_i, input_i, target_i in zip(input_adv, input, target):
-                self.verify(input_adv_i, input=input_i, target=target_i)
-        else:
-            self.verify(input_adv, input=input, target=target)
+        self.verify(input_adv, input=input, target=target)
 
     @abc.abstractmethod
     def verify(

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -130,8 +130,10 @@ class Enforcer:
             for modality in input_adv:
                 self(input_adv[modality], input=input[modality], target=target, modality=modality)
         elif isinstance(input_adv, (list, tuple)):
+            # We assume a modality-dictionary only contains tensors, but not list/tuple.
+            assert modality == "constraints"
             # The list or tuple input is a collection of sub-input and sub-target.
             for input_adv_i, input_i, target_i in zip(input_adv, input, target):
-                self(input_adv_i, input=input_i, target=target_i)
+                self(input_adv_i, input=input_i, target=target_i, modality=modality)
         else:
             raise ValueError(f"Unsupported data type of input_adv: {type(input_adv)}.")

--- a/mart/configs/attack/enforcer/default.yaml
+++ b/mart/configs/attack/enforcer/default.yaml
@@ -1,4 +1,4 @@
 defaults:
   - constraints: null
 
-_target_: mart.attack.enforcer.Enforcer
+_target_: mart.attack.Enforcer

--- a/mart/configs/attack/enforcer/modality.yaml
+++ b/mart/configs/attack/enforcer/modality.yaml
@@ -1,1 +1,0 @@
-_target_: mart.attack.ModalityEnforcer

--- a/mart/configs/attack/enforcer/modality.yaml
+++ b/mart/configs/attack/enforcer/modality.yaml
@@ -1,0 +1,1 @@
+_target_: mart.attack.ModalityEnforcer

--- a/mart/configs/attack/object_detection_rgb_mask_adversary.yaml
+++ b/mart/configs/attack/object_detection_rgb_mask_adversary.yaml
@@ -8,7 +8,6 @@ defaults:
   - objective: zero_ap
   - gain: rcnn_training_loss
   - composer: overlay
-  - enforcer: modality
   - enforcer/constraints@enforcer.rgb: [mask, pixel_range]
 
 # Make a 5-step attack for the demonstration purpose.

--- a/mart/configs/attack/object_detection_rgb_mask_adversary.yaml
+++ b/mart/configs/attack/object_detection_rgb_mask_adversary.yaml
@@ -1,0 +1,22 @@
+defaults:
+  - iterative_sgd
+  - perturber: batch
+  - perturber/initializer: constant
+  - perturber/gradient_modifier: sign
+  - perturber/projector: mask_range
+  - callbacks: [progress_bar, image_visualizer]
+  - objective: zero_ap
+  - gain: rcnn_training_loss
+  - composer: overlay
+  - enforcer: modality
+  - enforcer/constraints@enforcer.rgb: [mask, pixel_range]
+
+# Make a 5-step attack for the demonstration purpose.
+optimizer:
+  lr: 55
+
+max_iters: 5
+
+perturber:
+  initializer:
+    constant: 127

--- a/mart/configs/attack/object_detection_rgb_mask_adversary.yaml
+++ b/mart/configs/attack/object_detection_rgb_mask_adversary.yaml
@@ -8,6 +8,7 @@ defaults:
   - objective: zero_ap
   - gain: rcnn_training_loss
   - composer: overlay
+  - enforcer: default
   - enforcer/constraints@enforcer.rgb: [mask, pixel_range]
 
 # Make a 5-step attack for the demonstration purpose.

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -7,7 +7,7 @@
 import pytest
 import torch
 
-from mart.attack.enforcer import ConstraintViolated, Integer, Lp, Mask, Range
+from mart.attack.enforcer import ConstraintViolated, Enforcer, Integer, Lp, Mask, Range
 
 
 def test_constraint_range():
@@ -67,3 +67,50 @@ def test_constraint_mask():
     constraint(input + perturbation * mask, input=input, target=target)
     with pytest.raises(ConstraintViolated):
         constraint(input + perturbation, input=input, target=target)
+
+
+def test_enforcer_non_modality():
+    enforcer = Enforcer(constraints={"range": Range(min=0, max=255)})
+
+    input = torch.tensor([0, 0, 0])
+    perturbation = torch.tensor([0, 128, 255])
+    input_adv = input + perturbation
+    target = None
+
+    # tensor input.
+    enforcer(input_adv, input=input, target=target)
+    # list of tensor input.
+    enforcer([input_adv], input=[input], target=[target])
+
+    perturbation = torch.tensor([0, -1, 255])
+    input_adv = input + perturbation
+
+    with pytest.raises(ConstraintViolated):
+        enforcer(input_adv, input=input, target=target)
+
+    with pytest.raises(ConstraintViolated):
+        enforcer([input_adv], input=[input], target=[target])
+
+
+def test_enforcer_modality():
+    # Assume a rgb modality.
+    enforcer = Enforcer(rgb={"range": Range(min=0, max=255)})
+
+    input = torch.tensor([0, 0, 0])
+    perturbation = torch.tensor([0, 128, 255])
+    input_adv = input + perturbation
+    target = None
+
+    # Dictionary input.
+    enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
+    # List of dictionary input.
+    enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
+
+    perturbation = torch.tensor([0, -1, 255])
+    input_adv = input + perturbation
+
+    with pytest.raises(ConstraintViolated):
+        enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
+
+    with pytest.raises(ConstraintViolated):
+        enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -81,6 +81,8 @@ def test_enforcer_non_modality():
     enforcer(input_adv, input=input, target=target)
     # list of tensor input.
     enforcer([input_adv], input=[input], target=[target])
+    # tuple of tensor input.
+    enforcer((input_adv,), input=(input,), target=(target,))
 
     perturbation = torch.tensor([0, -1, 255])
     input_adv = input + perturbation
@@ -90,6 +92,9 @@ def test_enforcer_non_modality():
 
     with pytest.raises(ConstraintViolated):
         enforcer([input_adv], input=[input], target=[target])
+
+    with pytest.raises(ConstraintViolated):
+        enforcer((input_adv,), input=(input,), target=(target,))
 
 
 def test_enforcer_modality():
@@ -105,6 +110,8 @@ def test_enforcer_modality():
     enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
     # List of dictionary input.
     enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
+    # Tuple of dictionary input.
+    enforcer(({"rgb": input_adv},), input=({"rgb": input},), target=(target,))
 
     perturbation = torch.tensor([0, -1, 255])
     input_adv = input + perturbation
@@ -114,3 +121,6 @@ def test_enforcer_modality():
 
     with pytest.raises(ConstraintViolated):
         enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
+
+    with pytest.raises(ConstraintViolated):
+        enforcer(({"rgb": input_adv},), input=({"rgb": input},), target=(target,))


### PR DESCRIPTION
# What does this PR do?

This PR makes Enforcer aware of modalities in input, and compatible with existing configs without modality.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest tests/test_enforcer.py`

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
