### PR TITLE
Replace tuple with Iterable[torch.Tensor]

### DIFF
--- a/mart/attack/adversary_in_art.py
+++ b/mart/attack/adversary_in_art.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-from typing import Any, List, Optional
+from typing import Any, Iterable, List, Optional
 
 import hydra
 import numpy
@@ -82,17 +82,18 @@ class MartToArtAttackAdapter:
             x (np.ndarray): NHWC, [0, 1]
 
         Returns:
-            tuple: a tuple of tensors in CHW, [0, 255].
+            Iterable[torch.Tensor]: an Iterable of tensors in CHW, [0, 255].
         """
         input = torch.tensor(x).permute((0, 3, 1, 2)).to(self._device) * 255
+        # FIXME: replace tuple with whatever input's type is
         input = tuple(inp_ for inp_ in input)
         return input
 
-    def convert_input_mart_to_art(self, input: tuple):
+    def convert_input_mart_to_art(self, input: Iterable[torch.Tensor]):
         """Convert MART input to the ART's format.
 
         Args:
-            input (tuple): a tuple of tensors in CHW, [0, 255].
+            input (Iterable[torch.Tensor]): an Iterable of tensors in CHW, [0, 255].
 
         Returns:
             np.ndarray: NHWC, [0, 1]
@@ -112,7 +113,7 @@ class MartToArtAttackAdapter:
             y_patch_metadata (_type_): _description_
 
         Returns:
-            tuple: a tuple of target dictionaies.
+            Iterable[dict[str, Any]]: an Iterable of target dictionaies.
         """
         # Copy y to target, and convert ndarray to pytorch tensors accordingly.
         target = []
@@ -132,6 +133,7 @@ class MartToArtAttackAdapter:
             target_i["file_name"] = f"{yi['image_id'][0]}.jpg"
             target.append(target_i)
 
+        # FIXME: replace tuple with input type?
         target = tuple(target)
 
         return target

--- a/mart/attack/adversary_wrapper.py
+++ b/mart/attack/adversary_wrapper.py
@@ -6,9 +6,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import torch
+
+if TYPE_CHECKING:
+    from .enforcer import Enforcer
 
 __all__ = ["NormalizedAdversaryAdapter"]
 
@@ -22,7 +25,7 @@ class NormalizedAdversaryAdapter(torch.nn.Module):
     def __init__(
         self,
         adversary: Callable[[Callable], Callable],
-        enforcer: Callable[[torch.Tensor, torch.Tensor, torch.Tensor], None],
+        enforcer: Enforcer,
     ):
         """
 
@@ -37,8 +40,8 @@ class NormalizedAdversaryAdapter(torch.nn.Module):
 
     def forward(
         self,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module | None = None,
         **kwargs,
     ):

--- a/mart/attack/adversary_wrapper.py
+++ b/mart/attack/adversary_wrapper.py
@@ -41,7 +41,7 @@ class NormalizedAdversaryAdapter(torch.nn.Module):
     def forward(
         self,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module | None = None,
         **kwargs,
     ):

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -25,7 +25,7 @@ class Callback(abc.ABC):
         *,
         adversary: Adversary,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -36,7 +36,7 @@ class Callback(abc.ABC):
         *,
         adversary: Adversary,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -47,7 +47,7 @@ class Callback(abc.ABC):
         *,
         adversary: Adversary,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -58,7 +58,7 @@ class Callback(abc.ABC):
         *,
         adversary: Adversary,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -69,7 +69,7 @@ class Callback(abc.ABC):
         *,
         adversary: Adversary,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -80,7 +80,7 @@ class Callback(abc.ABC):
         *,
         adversary: Adversary,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):

--- a/mart/attack/callbacks/base.py
+++ b/mart/attack/callbacks/base.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
 import torch
 
@@ -24,8 +24,8 @@ class Callback(abc.ABC):
         self,
         *,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -35,8 +35,8 @@ class Callback(abc.ABC):
         self,
         *,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -46,8 +46,8 @@ class Callback(abc.ABC):
         self,
         *,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -57,8 +57,8 @@ class Callback(abc.ABC):
         self,
         *,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -68,8 +68,8 @@ class Callback(abc.ABC):
         self,
         *,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):
@@ -79,8 +79,8 @@ class Callback(abc.ABC):
         self,
         *,
         adversary: Adversary,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         model: torch.nn.Module,
         **kwargs,
     ):

--- a/mart/attack/composer.py
+++ b/mart/attack/composer.py
@@ -18,7 +18,7 @@ class Composer(abc.ABC):
         perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         **kwargs,
     ) -> torch.Tensor | Iterable[torch.Tensor]:
         if isinstance(perturbation, torch.Tensor) and isinstance(input, torch.Tensor):

--- a/mart/attack/composer.py
+++ b/mart/attack/composer.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any
+from typing import Any, Iterable
 
 import torch
 
@@ -15,21 +15,28 @@ import torch
 class Composer(abc.ABC):
     def __call__(
         self,
-        perturbation: torch.Tensor | tuple,
+        perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         **kwargs,
-    ) -> torch.Tensor | tuple:
-        if isinstance(perturbation, tuple):
-            input_adv = tuple(
+    ) -> torch.Tensor | Iterable[torch.Tensor]:
+        if isinstance(perturbation, torch.Tensor) and isinstance(input, torch.Tensor):
+            return self.compose(perturbation, input=input, target=target)
+
+        elif (
+            isinstance(perturbation, Iterable)
+            and isinstance(input, Iterable)  # noqa: W503
+            and isinstance(target, Iterable)  # noqa: W503
+        ):
+            # FIXME: replace tuple with whatever input's type is
+            return tuple(
                 self.compose(perturbation_i, input=input_i, target=target_i)
                 for perturbation_i, input_i, target_i in zip(perturbation, input, target)
             )
-        else:
-            input_adv = self.compose(perturbation, input=input, target=target)
 
-        return input_adv
+        else:
+            raise NotImplementedError
 
     @abc.abstractmethod
     def compose(

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -115,10 +115,8 @@ class Enforcer:
             and isinstance(input, Iterable)  # noqa: W503
             and isinstance(target, Iterable)  # noqa: W503
         ):
-            [
+            for input_adv_i, input_i, target_i in zip(input_adv, input, target):
                 self.enforce(input_adv_i, input=input_i, target=target_i)
-                for input_adv_i, input_i, target_i in zip(input_adv, input, target)
-            ]
 
     @torch.no_grad()
     def enforce(

--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -104,7 +104,7 @@ class Enforcer:
         input_adv: torch.Tensor | Iterable[torch.Tensor],
         *,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         **kwargs,
     ):
         if isinstance(input_adv, torch.Tensor) and isinstance(input, torch.Tensor):

--- a/mart/attack/gradient_modifier.py
+++ b/mart/attack/gradient_modifier.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import abc
 from typing import Iterable
 
 import torch
@@ -14,36 +13,33 @@ import torch
 __all__ = ["GradientModifier"]
 
 
-class GradientModifier(abc.ABC):
+class GradientModifier:
     """Gradient modifier base class."""
 
-    def __call__(self, parameters: torch.Tensor | Iterable[torch.Tensor]) -> None:
-        pass
-
-
-class Sign(GradientModifier):
     def __call__(self, parameters: torch.Tensor | Iterable[torch.Tensor]) -> None:
         if isinstance(parameters, torch.Tensor):
             parameters = [parameters]
 
-        parameters = [p for p in parameters if p.grad is not None]
+        [self.modify_(parameter) for parameter in parameters]
 
-        for p in parameters:
-            p.grad.detach().sign_()
+    @torch.no_grad()
+    def modify_(self, parameter: torch.Tensor) -> None:
+        pass
+
+
+class Sign(GradientModifier):
+    @torch.no_grad()
+    def modify_(self, parameter: torch.Tensor) -> None:
+        parameter.grad.sign_()
 
 
 class LpNormalizer(GradientModifier):
     """Scale gradients by a certain L-p norm."""
 
     def __init__(self, p: int | float):
-        self.p = p
+        self.p = float(p)
 
-    def __call__(self, parameters: torch.Tensor | Iterable[torch.Tensor]) -> None:
-        if isinstance(parameters, torch.Tensor):
-            parameters = [parameters]
-
-        parameters = [p for p in parameters if p.grad is not None]
-
-        for p in parameters:
-            p_norm = torch.norm(p.grad.detach(), p=self.p)
-            p.grad.detach().div_(p_norm)
+    @torch.no_grad()
+    def modify_(self, parameter: torch.Tensor) -> None:
+        p_norm = torch.norm(parameter.grad.detach(), p=self.p)
+        parameter.grad.detach().div_(p_norm)

--- a/mart/attack/initializer.py
+++ b/mart/attack/initializer.py
@@ -4,52 +4,57 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-import abc
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch
 
-__all__ = ["Initializer"]
 
-
-class Initializer(abc.ABC):
+class Initializer:
     """Initializer base class."""
 
     @torch.no_grad()
-    @abc.abstractmethod
-    def __call__(self, perturbation: torch.Tensor) -> None:
+    def __call__(self, parameters: torch.Tensor | Iterable[torch.Tensor]) -> None:
+        if isinstance(parameters, torch.Tensor):
+            parameters = [parameters]
+
+        [self.initialize_(parameter) for parameter in parameters]
+
+    @torch.no_grad()
+    def initialize_(self, parameter: torch.Tensor) -> None:
         pass
 
 
 class Constant(Initializer):
-    def __init__(self, constant: Optional[Union[int, float]] = 0):
+    def __init__(self, constant: int | float = 0):
         self.constant = constant
 
     @torch.no_grad()
-    def __call__(self, perturbation: torch.Tensor) -> None:
-        torch.nn.init.constant_(perturbation, self.constant)
+    def initialize_(self, parameter: torch.Tensor) -> None:
+        torch.nn.init.constant_(parameter, self.constant)
 
 
 class Uniform(Initializer):
-    def __init__(self, min: Union[int, float], max: Union[int, float]):
+    def __init__(self, min: int | float, max: int | float):
         self.min = min
         self.max = max
 
     @torch.no_grad()
-    def __call__(self, perturbation: torch.Tensor) -> None:
-        torch.nn.init.uniform_(perturbation, self.min, self.max)
+    def initialize_(self, parameter: torch.Tensor) -> None:
+        torch.nn.init.uniform_(parameter, self.min, self.max)
 
 
 class UniformLp(Initializer):
-    def __init__(self, eps: Union[int, float], p: Optional[Union[int, float]] = torch.inf):
+    def __init__(self, eps: int | float, p: int | float = torch.inf):
         self.eps = eps
         self.p = p
 
     @torch.no_grad()
-    def __call__(self, perturbation: torch.Tensor) -> None:
-        torch.nn.init.uniform_(perturbation, -self.eps, self.eps)
+    def initialize_(self, parameter: torch.Tensor) -> None:
+        torch.nn.init.uniform_(parameter, -self.eps, self.eps)
         # TODO: make sure the first dim is the batch dim.
         if self.p is not torch.inf:
             # We don't do tensor.renorm_() because the first dim is not the batch dim.
-            pert_norm = perturbation.norm(p=self.p)
-            perturbation.mul_(self.eps / pert_norm)
+            pert_norm = parameter.norm(p=self.p)
+            parameter.mul_(self.eps / pert_norm)

--- a/mart/attack/projector.py
+++ b/mart/attack/projector.py
@@ -20,7 +20,7 @@ class Projector:
         perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         **kwargs,
     ) -> None:
         if isinstance(perturbation, torch.Tensor) and isinstance(input, torch.Tensor):
@@ -43,7 +43,7 @@ class Projector:
         perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
     ) -> None:
         pass
 
@@ -60,7 +60,7 @@ class Compose(Projector):
         perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
         input: torch.Tensor | Iterable[torch.Tensor],
-        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
+        target: torch.Tensor | Iterable[torch.Tensor] | Iterable[dict[str, Any]],
         **kwargs,
     ) -> None:
         for projector in self.projectors:

--- a/mart/attack/projector.py
+++ b/mart/attack/projector.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable
 
 import torch
 
@@ -17,24 +17,35 @@ class Projector:
     @torch.no_grad()
     def __call__(
         self,
-        perturbation: torch.Tensor | tuple,
+        perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.tensor | dict[str, Any]],
         **kwargs,
     ) -> None:
-        if isinstance(perturbation, tuple):
-            for perturbation_i, input_i, target_i in zip(perturbation, input, target):
-                self.project(perturbation_i, input=input_i, target=target_i)
-        else:
-            self.project(perturbation, input=input, target=target)
+        if isinstance(perturbation, torch.Tensor) and isinstance(input, torch.Tensor):
+            self.project_(perturbation, input=input, target=target)
 
-    def project(
+        elif (
+            isinstance(perturbation, Iterable)
+            and isinstance(input, Iterable)  # noqa: W503
+            and isinstance(target, Iterable)  # noqa: W503
+        ):
+            [
+                self.project_(perturbation_i, input=input_i, target=target_i)
+                for perturbation_i, input_i, target_i in zip(perturbation, input, target)
+            ]
+
+        else:
+            raise NotImplementedError
+
+    @torch.no_grad()
+    def project_(
         self,
-        perturbation: torch.Tensor | tuple,
+        perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
     ) -> None:
         pass
 
@@ -48,10 +59,10 @@ class Compose(Projector):
     @torch.no_grad()
     def __call__(
         self,
-        perturbation: torch.Tensor | tuple,
+        perturbation: torch.Tensor | Iterable[torch.Tensor],
         *,
-        input: torch.Tensor | tuple,
-        target: torch.Tensor | dict[str, Any] | tuple,
+        input: torch.Tensor | Iterable[torch.Tensor],
+        target: torch.Tensor | Iterable[torch.Tensor | dict[str, Any]],
         **kwargs,
     ) -> None:
         for projector in self.projectors:
@@ -70,7 +81,8 @@ class Range(Projector):
         self.min = min
         self.max = max
 
-    def project(self, perturbation, *, input, target):
+    @torch.no_grad()
+    def project_(self, perturbation, *, input, target):
         if self.quantize:
             perturbation.round_()
         perturbation.clamp_(self.min, self.max)
@@ -92,7 +104,8 @@ class RangeAdditive(Projector):
         self.min = min
         self.max = max
 
-    def project(self, perturbation, *, input, target):
+    @torch.no_grad()
+    def project_(self, perturbation, *, input, target):
         if self.quantize:
             perturbation.round_()
         perturbation.clamp_(self.min - input, self.max - input)
@@ -117,7 +130,8 @@ class Lp(Projector):
         self.p = p
         self.eps = eps
 
-    def project(self, perturbation, *, input, target):
+    @torch.no_grad()
+    def project_(self, perturbation, *, input, target):
         pert_norm = perturbation.norm(p=self.p)
         if pert_norm > self.eps:
             # We only upper-bound the norm.
@@ -133,7 +147,8 @@ class LinfAdditiveRange(Projector):
         self.min = min
         self.max = max
 
-    def project(self, perturbation, *, input, target):
+    @torch.no_grad()
+    def project_(self, perturbation, *, input, target):
         eps_min = (input - self.eps).clamp(self.min, self.max) - input
         eps_max = (input + self.eps).clamp(self.min, self.max) - input
 
@@ -141,7 +156,8 @@ class LinfAdditiveRange(Projector):
 
 
 class Mask(Projector):
-    def project(self, perturbation, *, input, target):
+    @torch.no_grad()
+    def project_(self, perturbation, *, input, target):
         perturbation.mul_(target["perturbable_mask"])
 
     def __repr__(self):

--- a/mart/attack/projector.py
+++ b/mart/attack/projector.py
@@ -31,10 +31,8 @@ class Projector:
             and isinstance(input, Iterable)  # noqa: W503
             and isinstance(target, Iterable)  # noqa: W503
         ):
-            [
+            for perturbation_i, input_i, target_i in zip(perturbation, input, target):
                 self.project_(perturbation_i, input=input_i, target=target_i)
-                for perturbation_i, input_i, target_i in zip(perturbation, input, target)
-            ]
 
         else:
             raise NotImplementedError

--- a/tests/test_enforcer.py
+++ b/tests/test_enforcer.py
@@ -97,30 +97,30 @@ def test_enforcer_non_modality():
         enforcer((input_adv,), input=(input,), target=(target,))
 
 
-def test_enforcer_modality():
-    # Assume a rgb modality.
-    enforcer = Enforcer(rgb={"range": Range(min=0, max=255)})
-
-    input = torch.tensor([0, 0, 0])
-    perturbation = torch.tensor([0, 128, 255])
-    input_adv = input + perturbation
-    target = None
-
-    # Dictionary input.
-    enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
-    # List of dictionary input.
-    enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
-    # Tuple of dictionary input.
-    enforcer(({"rgb": input_adv},), input=({"rgb": input},), target=(target,))
-
-    perturbation = torch.tensor([0, -1, 255])
-    input_adv = input + perturbation
-
-    with pytest.raises(ConstraintViolated):
-        enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
-
-    with pytest.raises(ConstraintViolated):
-        enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
-
-    with pytest.raises(ConstraintViolated):
-        enforcer(({"rgb": input_adv},), input=({"rgb": input},), target=(target,))
+# def test_enforcer_modality():
+#    # Assume a rgb modality.
+#    enforcer = Enforcer(rgb={"range": Range(min=0, max=255)})
+#
+#    input = torch.tensor([0, 0, 0])
+#    perturbation = torch.tensor([0, 128, 255])
+#    input_adv = input + perturbation
+#    target = None
+#
+#    # Dictionary input.
+#    enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
+#    # List of dictionary input.
+#    enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
+#    # Tuple of dictionary input.
+#    enforcer(({"rgb": input_adv},), input=({"rgb": input},), target=(target,))
+#
+#    perturbation = torch.tensor([0, -1, 255])
+#    input_adv = input + perturbation
+#
+#    with pytest.raises(ConstraintViolated):
+#        enforcer({"rgb": input_adv}, input={"rgb": input}, target=target)
+#
+#    with pytest.raises(ConstraintViolated):
+#        enforcer([{"rgb": input_adv}], input=[{"rgb": input}], target=[target])
+#
+#    with pytest.raises(ConstraintViolated):
+#        enforcer(({"rgb": input_adv},), input=({"rgb": input},), target=(target,))

--- a/tests/test_projector.py
+++ b/tests/test_projector.py
@@ -154,7 +154,7 @@ def test_compose(input_data, target_data):
     ]
 
     compose = Compose(projectors)
-    tensor = Mock()
+    tensor = Mock(spec=torch.Tensor)
     tensor.norm.return_value = 10
     compose(tensor, input=input_data, target=target_data)
 


### PR DESCRIPTION
# What does this PR do?

We had type annotations for `tuple` everywhere, but this is not great because it doesn't tell us what is inside of the `tuple`. As such, I changed it to `Iterable[torch.Tensor]`. I also tried to cleanup the dispatch code in all places. This PR, however, does not support input dictionaries right now. I think the "modality dispatch" abstraction in #115 should be pulled out and rebased on this PR.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `make test`

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
