### PR TITLE
Improve progress bar for adversaries

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -82,7 +82,7 @@ class Adversary(pl.LightningModule):
                 callbacks=list(kwargs.pop("callbacks", {}).values()),  # dict to list of values
                 enable_model_summary=False,
                 enable_checkpointing=False,
-                # FIXME: Sometimes we don't need a progress bar, e.g. FGSM.
+                # We should disable progress bar in the progress_bar callback config if needed.
                 enable_progress_bar=True,
                 # detect_anomaly=True,
             )

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -82,7 +82,8 @@ class Adversary(pl.LightningModule):
                 callbacks=list(kwargs.pop("callbacks", {}).values()),  # dict to list of values
                 enable_model_summary=False,
                 enable_checkpointing=False,
-                enable_progress_bar=False,
+                # FIXME: Sometimes we don't need a progress bar, e.g. FGSM.
+                enable_progress_bar=True,
                 # detect_anomaly=True,
             )
 

--- a/mart/callbacks/progress_bar.py
+++ b/mart/callbacks/progress_bar.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-import tqdm
+from typing import Any
+
+import pytorch_lightning as pl
 from pytorch_lightning.callbacks import TQDMProgressBar
 
 __all__ = ["ProgressBar"]
@@ -20,3 +22,11 @@ class ProgressBar(TQDMProgressBar):
         bar.unit = "iter"
 
         return bar
+
+    def on_train_epoch_start(self, trainer: pl.Trainer, *_: Any) -> None:
+        super().on_train_epoch_start(trainer)
+
+        # So that it does not display negative rate.
+        self.main_progress_bar.initial = 0
+        # So that it does not display Epoch n.
+        self.main_progress_bar.set_description("Attack")

--- a/mart/callbacks/progress_bar.py
+++ b/mart/callbacks/progress_bar.py
@@ -16,7 +16,7 @@ __all__ = ["ProgressBar"]
 class ProgressBar(TQDMProgressBar):
     """Display progress bar of attack iterations with the gain value."""
 
-    def __init__(self, disable=False, *args, **kwargs):
+    def __init__(self, *args, disable=False, rename_metrics=None, **kwargs):
         if "process_position" not in kwargs:
             # Automatically place the progress bar by rank if position is not specified.
             # rank starts with 0
@@ -29,6 +29,9 @@ class ProgressBar(TQDMProgressBar):
 
         if disable:
             self.disable()
+
+        # E.g. rename loss as gain for adversary's progress bar.
+        self.rename_metrics = rename_metrics or {}
 
     def init_train_tqdm(self):
         bar = super().init_train_tqdm()
@@ -48,7 +51,8 @@ class ProgressBar(TQDMProgressBar):
         self.main_progress_bar.set_description(f"Attack@rank{rank_id}")
 
     def get_metrics(self, *args, **kwargs):
+        """Rename metrics on progress bar status."""
         metrics = super().get_metrics(*args, **kwargs)
-        # Display gain value in progress bar.
-        metrics["gain"] = metrics.pop("loss")
+        for old_name, new_name in self.rename_metrics.items():
+            metrics[new_name] = metrics.pop(old_name)
         return metrics

--- a/mart/callbacks/progress_bar.py
+++ b/mart/callbacks/progress_bar.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import TQDMProgressBar
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 __all__ = ["ProgressBar"]
 
@@ -19,6 +20,11 @@ class ProgressBar(TQDMProgressBar):
         super().__init__(*args, **kwargs)
         if disable:
             self.disable()
+
+        # rank starts with 0
+        rank_id = rank_zero_only.rank
+        # Adversary progress bars start at position 1, because the main progress bar takes position 0.
+        self._process_position = rank_id + 1
 
     def init_train_tqdm(self):
         bar = super().init_train_tqdm()
@@ -34,4 +40,5 @@ class ProgressBar(TQDMProgressBar):
         # So that it does not display negative rate.
         self.main_progress_bar.initial = 0
         # So that it does not display Epoch n.
-        self.main_progress_bar.set_description("Attack")
+        rank_id = rank_zero_only.rank
+        self.main_progress_bar.set_description(f"Attack@rank{rank_id}")

--- a/mart/callbacks/progress_bar.py
+++ b/mart/callbacks/progress_bar.py
@@ -15,6 +15,11 @@ __all__ = ["ProgressBar"]
 class ProgressBar(TQDMProgressBar):
     """Display progress bar of attack iterations with the gain value."""
 
+    def __init__(self, disable=False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if disable:
+            self.disable()
+
     def init_train_tqdm(self):
         bar = super().init_train_tqdm()
         bar.leave = False

--- a/mart/callbacks/progress_bar.py
+++ b/mart/callbacks/progress_bar.py
@@ -17,14 +17,18 @@ class ProgressBar(TQDMProgressBar):
     """Display progress bar of attack iterations with the gain value."""
 
     def __init__(self, disable=False, *args, **kwargs):
+        if "process_position" not in kwargs:
+            # Automatically place the progress bar by rank if position is not specified.
+            # rank starts with 0
+            rank_id = rank_zero_only.rank
+            # Adversary progress bars start at position 1, because the main progress bar takes position 0.
+            process_position = rank_id + 1
+            kwargs["process_position"] = process_position
+
         super().__init__(*args, **kwargs)
+
         if disable:
             self.disable()
-
-        # rank starts with 0
-        rank_id = rank_zero_only.rank
-        # Adversary progress bars start at position 1, because the main progress bar takes position 0.
-        self._process_position = rank_id + 1
 
     def init_train_tqdm(self):
         bar = super().init_train_tqdm()

--- a/mart/callbacks/progress_bar.py
+++ b/mart/callbacks/progress_bar.py
@@ -42,3 +42,9 @@ class ProgressBar(TQDMProgressBar):
         # So that it does not display Epoch n.
         rank_id = rank_zero_only.rank
         self.main_progress_bar.set_description(f"Attack@rank{rank_id}")
+
+    def get_metrics(self, *args, **kwargs):
+        metrics = super().get_metrics(*args, **kwargs)
+        # Display gain value in progress bar.
+        metrics["gain"] = metrics.pop("loss")
+        return metrics

--- a/mart/configs/attack/adversary.yaml
+++ b/mart/configs/attack/adversary.yaml
@@ -1,3 +1,6 @@
+defaults:
+  - /callbacks@callbacks: [progress_bar]
+
 _target_: mart.attack.Adversary
 perturber: ???
 composer: ???

--- a/mart/configs/attack/classification_eps1.75_fgsm.yaml
+++ b/mart/configs/attack/classification_eps1.75_fgsm.yaml
@@ -27,3 +27,8 @@ perturber:
 
   projector:
     eps: 1.75
+
+# We can turn off progress bar for one-step attack.
+callbacks:
+  progress_bar:
+    disable: true

--- a/mart/configs/attack/classification_eps2_pgd10_step1.yaml
+++ b/mart/configs/attack/classification_eps2_pgd10_step1.yaml
@@ -10,7 +10,6 @@ defaults:
   - objective: misclassification
   - enforcer: default
   - enforcer/constraints: [lp, pixel_range]
-  - /callbacks@callbacks: [progress_bar]
 
 enforcer:
   constraints:

--- a/mart/configs/attack/classification_eps2_pgd10_step1.yaml
+++ b/mart/configs/attack/classification_eps2_pgd10_step1.yaml
@@ -10,6 +10,7 @@ defaults:
   - objective: misclassification
   - enforcer: default
   - enforcer/constraints: [lp, pixel_range]
+  - /callbacks@callbacks: [progress_bar]
 
 enforcer:
   constraints:

--- a/mart/configs/callbacks/progress_bar.yaml
+++ b/mart/configs/callbacks/progress_bar.yaml
@@ -1,3 +1,5 @@
 progress_bar:
   _target_: mart.callbacks.ProgressBar
   process_position: 1
+  # Enable progress bar for adversary by default.
+  disable: false

--- a/mart/configs/callbacks/progress_bar.yaml
+++ b/mart/configs/callbacks/progress_bar.yaml
@@ -1,5 +1,4 @@
 progress_bar:
   _target_: mart.callbacks.ProgressBar
-  process_position: 1
   # Enable progress bar for adversary by default.
   disable: false

--- a/mart/configs/callbacks/progress_bar.yaml
+++ b/mart/configs/callbacks/progress_bar.yaml
@@ -2,3 +2,5 @@ progress_bar:
   _target_: mart.callbacks.ProgressBar
   # Enable progress bar for adversary by default.
   disable: false
+  rename_metrics:
+    loss: gain


### PR DESCRIPTION
# What does this PR do?

This PR tries to improve the progress bar for adversaries.

- [x] Replace title `Epoch n` with `Attack`.
- [x] Fix negative rate.
- [x] Make a default progress bar for adversary.
- [x] Turn on/off progress bar in attack configuration.
- [x] Hide progress bar for FGSM by default.
- [x] Display multiple progress bars in the multi-rank environment.
- [x] Display gain instead of loss.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu` achieves 70.09% accuracy.
- [x] `python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256` achieves 69.84% accuracy.

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
