### PR TITLE
Hide `Adversary` instead of `Adversary.Perturber`

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -75,7 +75,7 @@ class Adversary(pl.LightningModule):
             self._attacker = partial(
                 pl.Trainer,
                 num_sanity_val_steps=0,
-                logger=False,
+                logger=list(kwargs.pop("logger", {}).values()),
                 max_epochs=0,
                 limit_train_batches=kwargs.pop("max_iters", 10),
                 callbacks=list(kwargs.pop("callbacks", {}).values()),  # dict to list of values

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -58,8 +58,7 @@ class Adversary(pl.LightningModule):
         """
         super().__init__()
 
-        # Hide the perturber module in a list, so that perturbation is not exported as a parameter in the model checkpoint.
-        self._perturber = [perturber]
+        self.perturber = perturber
         self.composer = composer
         self.optimizer = optimizer
         if not isinstance(self.optimizer, OptimizerFactory):
@@ -93,11 +92,6 @@ class Adversary(pl.LightningModule):
             # the number of attack steps via limit_train_batches.
             assert self._attacker.max_epochs == 0
             assert self._attacker.limit_train_batches > 0
-
-    @property
-    def perturber(self) -> Perturber:
-        # Hide the perturber module in a list, so that perturbation is not exported as a parameter in the model checkpoint.
-        return self._perturber[0]
 
     def configure_optimizers(self):
         return self.optimizer(self.perturber)

--- a/mart/configs/experiment/CIFAR10_CNN_Adv.yaml
+++ b/mart/configs/experiment/CIFAR10_CNN_Adv.yaml
@@ -9,6 +9,9 @@ task_name: "CIFAR10_CNN_Adv"
 tags: ["adv", "fat"]
 
 model:
+  # Hide Adversary modules from model state_dict, checkpoint and parameters.
+  hide_modules: ["input_adv_training", "input_adv_test"]
+
   training_sequence:
     seq005: input_adv_training
 

--- a/mart/configs/experiment/COCO_TorchvisionFasterRCNN_Adv.yaml
+++ b/mart/configs/experiment/COCO_TorchvisionFasterRCNN_Adv.yaml
@@ -9,6 +9,9 @@ task_name: "COCO_TorchvisionFasterRCNN_Adv"
 tags: ["adv"]
 
 model:
+  # Hide Adversary modules from model state_dict, checkpoint and parameters.
+  hide_modules: ["input_adv_test"]
+
   test_sequence:
     seq005: input_adv_test
 

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -34,6 +34,7 @@ class LitModular(LightningModule):
         test_metrics=None,
         weights_fpath=None,
         strict=True,
+        hide_modules=None,
     ):
         super().__init__()
 
@@ -59,7 +60,7 @@ class LitModular(LightningModule):
             "validation": validation_sequence,
             "test": test_sequence,
         }
-        self.model = SequentialDict(modules, sequences)
+        self.model = SequentialDict(modules, sequences=sequences, hide_modules=hide_modules)
 
         if weights_fpath is not None:
             self.model.load_state_dict(torch.load(weights_fpath), strict=strict)

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -135,13 +135,13 @@ def test_hidden_params_after_forward(input_data, target_data, perturbation):
 
     output_data = adversary(input=input_data, target=target_data, model=model, sequence=sequence)
 
-    # Adversarial perturbation will not have parameter even after forward is called.
+    # Adversarial perturbation will have parameter after forward is called.
     params = [p for p in adversary.parameters()]
-    assert len(params) == 0
+    assert len(params) == 1
 
-    # Adversarial perturbation should not have any state dict items being exported to the model checkpoint.
+    # Adversarial perturbation should have perturbation in state_dict.
     state_dict = adversary.state_dict()
-    assert len(state_dict) == 0
+    assert len(state_dict) == 1
 
 
 def test_perturbation(input_data, target_data, perturbation):


### PR DESCRIPTION
# What does this PR do?

Hide the `Adversary` modules instead of `Adversary.Perturber`, so that we can make use of all `Trainer` features in `Adversary`.

We may configure not to hide `Adversary` for computing universal perturbations.

Depends on #144

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70.23%

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
