### PR TITLE
Allow `LitModular` to load from checkpoints with states of `Adversary`

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -34,7 +34,6 @@ class Adversary(pl.LightningModule):
     def __init__(
         self,
         *,
-        disable_loading_from_state_dict: bool = True,
         perturber: Perturber,
         composer: Composer,
         optimizer: OptimizerFactory | Callable[[Any], torch.optim.Optimizer],
@@ -48,7 +47,6 @@ class Adversary(pl.LightningModule):
         """_summary_
 
         Args:
-            disable_loading_from_state_dict (bool): Don't load state_dict if True.
             perturber (Perturber): A MART Perturber.
             composer (Composer): A MART Composer.
             optimizer (OptimizerFactory | Callable[[Any], torch.optim.Optimizer]): A MART OptimizerFactory or partial that returns an Optimizer when given params.
@@ -60,11 +58,11 @@ class Adversary(pl.LightningModule):
         """
         super().__init__()
 
-        if disable_loading_from_state_dict:
+        # Avoid resuming perturbation from a saved checkpoint.
+        self._register_load_state_dict_pre_hook(
             # Appear to have consumed the state_dict.
-            self._register_load_state_dict_pre_hook(
-                lambda state_dict, *args, **kwargs: state_dict.clear()
-            )
+            lambda state_dict, *args, **kwargs: state_dict.clear()
+        )
 
         self.perturber = perturber
         self.composer = composer

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -60,7 +60,13 @@ class Adversary(pl.LightningModule):
         """
         super().__init__()
 
-        self.disable_loading_from_state_dict = disable_loading_from_state_dict
+        def _disable_loading_from_state_dict(state_dict, *args, **kwargs):
+            if disable_loading_from_state_dict:
+                # Appear to have consumed the state_dict.
+                state_dict.clear()
+
+        self._register_load_state_dict_pre_hook(_disable_loading_from_state_dict)
+
         self.perturber = perturber
         self.composer = composer
         self.optimizer = optimizer
@@ -197,10 +203,3 @@ class Adversary(pl.LightningModule):
         # This is a problem when this LightningModule has parameters, so we stop this from
         # happening by ignoring the call to cpu().
         pass
-
-    def _load_from_state_dict(self, state_dict, *args, **kwargs):
-        if self.disable_loading_from_state_dict:
-            # Appear to have consumed the state_dict.
-            state_dict.clear()
-        else:
-            super()._load_from_state_dict(state_dict, *args, **kwargs)

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -61,8 +61,6 @@ class Adversary(pl.LightningModule):
         super().__init__()
 
         self.disable_loading_from_state_dict = disable_loading_from_state_dict
-
-        # Hide the perturber module in a list, so that perturbation is not exported as a parameter in the model checkpoint.
         self.perturber = perturber
         self.composer = composer
         self.optimizer = optimizer

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -61,6 +61,7 @@ class Adversary(pl.LightningModule):
         super().__init__()
 
         if disable_loading_from_state_dict:
+            # Appear to have consumed the state_dict.
             self._register_load_state_dict_pre_hook(
                 lambda state_dict, *args, **kwargs: state_dict.clear()
             )

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -61,12 +61,9 @@ class Adversary(pl.LightningModule):
         super().__init__()
 
         if disable_loading_from_state_dict:
-
-            def _disable_loading_from_state_dict(state_dict, *args, **kwargs):
-                # Appear to have consumed the state_dict.
-                state_dict.clear()
-
-            self._register_load_state_dict_pre_hook(_disable_loading_from_state_dict)
+            self._register_load_state_dict_pre_hook(
+                lambda state_dict, *args, **kwargs: state_dict.clear()
+            )
 
         self.perturber = perturber
         self.composer = composer

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -59,7 +59,7 @@ class Adversary(pl.LightningModule):
         super().__init__()
 
         # Hide the perturber module in a list, so that perturbation is not exported as a parameter in the model checkpoint.
-        self._perturber = [perturber]
+        self.perturber = perturber
         self.composer = composer
         self.optimizer = optimizer
         if not isinstance(self.optimizer, OptimizerFactory):
@@ -93,11 +93,6 @@ class Adversary(pl.LightningModule):
             # the number of attack steps via limit_train_batches.
             assert self._attacker.max_epochs == 0
             assert self._attacker.limit_train_batches > 0
-
-    @property
-    def perturber(self) -> Perturber:
-        # Hide the perturber module in a list, so that perturbation is not exported as a parameter in the model checkpoint.
-        return self._perturber[0]
 
     def configure_optimizers(self):
         return self.optimizer(self.perturber)

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -60,11 +60,12 @@ class Adversary(pl.LightningModule):
         """
         super().__init__()
 
-        def _disable_loading_from_state_dict(state_dict, *args, **kwargs):
-            # Appear to have consumed the state_dict.
-            state_dict.clear()
-
         if disable_loading_from_state_dict:
+
+            def _disable_loading_from_state_dict(state_dict, *args, **kwargs):
+                # Appear to have consumed the state_dict.
+                state_dict.clear()
+
             self._register_load_state_dict_pre_hook(_disable_loading_from_state_dict)
 
         self.perturber = perturber

--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -61,11 +61,11 @@ class Adversary(pl.LightningModule):
         super().__init__()
 
         def _disable_loading_from_state_dict(state_dict, *args, **kwargs):
-            if disable_loading_from_state_dict:
-                # Appear to have consumed the state_dict.
-                state_dict.clear()
+            # Appear to have consumed the state_dict.
+            state_dict.clear()
 
-        self._register_load_state_dict_pre_hook(_disable_loading_from_state_dict)
+        if disable_loading_from_state_dict:
+            self._register_load_state_dict_pre_hook(_disable_loading_from_state_dict)
 
         self.perturber = perturber
         self.composer = composer

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -34,7 +34,6 @@ class LitModular(LightningModule):
         test_metrics=None,
         weights_fpath=None,
         strict=True,
-        ignore_state_dict_contains=["input_adv_"],
     ):
         super().__init__()
 
@@ -80,8 +79,6 @@ class LitModular(LightningModule):
 
         self.test_step_log = test_step_log or []
         self.test_metrics = test_metrics
-
-        self.ignore_state_dict_contains = ignore_state_dict_contains
 
     def configure_optimizers(self):
         config = {}
@@ -228,13 +225,3 @@ class LitModular(LightningModule):
         enumerate_metric(metrics, prefix)
 
         self.log_dict(metrics_dict, prog_bar=prog_bar)
-
-    def on_load_checkpoint(self, ckpt):
-        """Remove some keys from state_dict before loading the checkpoint."""
-        state_dict = ckpt["state_dict"]
-
-        for keyword in self.ignore_state_dict_contains:
-            for key in state_dict.keys():
-                if keyword in key:
-                    logger.info(f"Delete checkpoint state_dict key: {key}")
-                    del state_dict[key]

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -34,6 +34,7 @@ class LitModular(LightningModule):
         test_metrics=None,
         weights_fpath=None,
         strict=True,
+        ignore_state_dict_contains=["input_adv_"],
     ):
         super().__init__()
 
@@ -79,6 +80,8 @@ class LitModular(LightningModule):
 
         self.test_step_log = test_step_log or []
         self.test_metrics = test_metrics
+
+        self.ignore_state_dict_contains = ignore_state_dict_contains
 
     def configure_optimizers(self):
         config = {}
@@ -225,3 +228,13 @@ class LitModular(LightningModule):
         enumerate_metric(metrics, prefix)
 
         self.log_dict(metrics_dict, prog_bar=prog_bar)
+
+    def on_load_checkpoint(self, ckpt):
+        """Remove some keys from state_dict before loading the checkpoint."""
+        state_dict = ckpt["state_dict"]
+
+        for keyword in self.ignore_state_dict_contains:
+            for key in state_dict.keys():
+                if keyword in key:
+                    logger.info(f"Delete checkpoint state_dict key: {key}")
+                    del state_dict[key]

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -167,7 +167,7 @@ def test_loading_perturbation_from_state_dict():
     # We should be able to load arbitrary state_dict, because Adversary ignores state_dict.
     # We want this behavior for Adversary because model checkpoints may include perturbation in state_dict
     # that is not loadable before initialization of perturbation.
-    adversary.load_state_dict({"perturbation": None})
+    adversary.load_state_dict({"perturber.perturbation": torch.tensor([1.0, 2.0])})
 
 
 def test_perturbation(input_data, target_data, perturbation):

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -135,13 +135,13 @@ def test_hidden_params_after_forward(input_data, target_data, perturbation):
 
     output_data = adversary(input=input_data, target=target_data, model=model, sequence=sequence)
 
-    # Adversarial perturbation will not have parameter even after forward is called.
+    # Adversarial perturbation will have one parameter after forward is called.
     params = [p for p in adversary.parameters()]
-    assert len(params) == 0
+    assert len(params) == 1
 
-    # Adversarial perturbation should not have any state dict items being exported to the model checkpoint.
+    # Adversarial perturbation should have one state dict item being exported to the model checkpoint.
     state_dict = adversary.state_dict()
-    assert len(state_dict) == 0
+    assert len(state_dict) == 1
 
 
 def test_perturbation(input_data, target_data, perturbation):

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -144,6 +144,32 @@ def test_hidden_params_after_forward(input_data, target_data, perturbation):
     assert len(state_dict) == 1
 
 
+def test_loading_perturbation_from_state_dict():
+    initializer = Mock()
+    composer = mart.attack.composer.Additive()
+    projector = Mock()
+
+    perturber = Perturber(initializer=initializer, projector=projector)
+
+    gain = Mock()
+    enforcer = Mock()
+    attacker = Mock(max_epochs=0, limit_train_batches=1, fit_loop=Mock(max_epochs=0))
+
+    adversary = Adversary(
+        perturber=perturber,
+        composer=composer,
+        optimizer=None,
+        gain=gain,
+        enforcer=enforcer,
+        attacker=attacker,
+    )
+
+    # We should be able to load arbitrary state_dict, because Adversary ignores state_dict.
+    # We want this behavior for Adversary because model checkpoints may include perturbation in state_dict
+    # that is not loadable before initialization of perturbation.
+    adversary.load_state_dict({"perturbation": None})
+
+
 def test_perturbation(input_data, target_data, perturbation):
     perturber = Mock(spec=Perturber, return_value=perturbation)
     composer = mart.attack.composer.Additive()

--- a/tests/test_adversary.py
+++ b/tests/test_adversary.py
@@ -169,6 +169,9 @@ def test_loading_perturbation_from_state_dict():
     # that is not loadable before initialization of perturbation.
     adversary.load_state_dict({"perturber.perturbation": torch.tensor([1.0, 2.0])})
 
+    # Adversary ignores load_state_dict() quietly, so perturbation is still None.
+    assert adversary.perturber.perturbation is None
+
 
 def test_perturbation(input_data, target_data, perturbation):
     perturber = Mock(spec=Perturber, return_value=perturbation)


### PR DESCRIPTION
# What does this PR do?

* Unhide `Adversary.perturber` to make use of all features of `pl.Trainer`.
* Use `Adversary._register_load_state_dict_pre_hook()` to avoid resuming from perturbation in a checkpoint.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70.08%

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
