### PR TITLE
Remove `*_step_end` from `LitModular`

### DIFF
--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -36,6 +36,9 @@ class LitModular(LightningModule):
         test_step_log=None,
         test_metrics=None,
         load_state_dict=None,
+        output_loss_key="loss",
+        output_preds_key="preds",
+        output_target_key="target",
     ):
         super().__init__()
 
@@ -88,6 +91,10 @@ class LitModular(LightningModule):
             logger.info(f"Loading state_dict {path} for {module.__class__.__name__}...")
             module.load_state_dict(torch.load(path, map_location="cpu"))
 
+        self.output_loss_key = output_loss_key
+        self.output_preds_key = output_preds_key
+        self.output_target_key = output_target_key
+
     def configure_optimizers(self):
         config = {}
         config["optimizer"] = self.optimizer_fn(self.model)
@@ -118,19 +125,15 @@ class LitModular(LightningModule):
         for name in self.training_step_log:
             self.log(f"training/{name}", output[name])
 
-        assert "loss" in output
-        return output
-
-    def training_step_end(self, output):
         if self.training_metrics is not None:
             # Some models only return loss in the training mode.
-            if "preds" not in output or "target" not in output:
+            if self.output_preds_key not in output or self.output_target_key not in output:
                 raise ValueError(
-                    "You have specified training_metrics, but the model does not return preds and target during training. You can either nullify training_metrics or configure the model to return preds and target in the training output."
+                    f"You have specified training_metrics, but the model does not return {self.output_preds_key} or {self.output_target_key} during training. You can either nullify training_metrics or configure the model to return {self.output_preds_key} and {self.output_target_key} in the training output."
                 )
-            self.training_metrics(output["preds"], output["target"])
-        loss = output.pop("loss")
-        return loss
+            self.training_metrics(output[self.output_preds_key], output[self.output_target_key])
+
+        return output[self.output_loss_key]
 
     def training_epoch_end(self, outputs):
         if self.training_metrics is not None:
@@ -152,13 +155,9 @@ class LitModular(LightningModule):
         for name in self.validation_step_log:
             self.log(f"validation/{name}", output[name])
 
-        return output
+        self.validation_metrics(output[self.output_preds_key], output[self.output_target_key])
 
-    def validation_step_end(self, output):
-        self.validation_metrics(output["preds"], output["target"])
-
-        # I don't know why this is required to prevent CUDA memory leak in validaiton and test. (Not required in training.)
-        output.clear()
+        return None
 
     def validation_epoch_end(self, outputs):
         metrics = self.validation_metrics.compute()
@@ -178,13 +177,9 @@ class LitModular(LightningModule):
         for name in self.test_step_log:
             self.log(f"test/{name}", output[name])
 
-        return output
+        self.test_metrics(output[self.output_preds_key], output[self.output_target_key])
 
-    def test_step_end(self, output):
-        self.test_metrics(output["preds"], output["target"])
-
-        # I don't know why this is required to prevent CUDA memory leak in validaiton and test. (Not required in training.)
-        output.clear()
+        return None
 
     def test_epoch_end(self, outputs):
         metrics = self.test_metrics.compute()

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -125,6 +125,10 @@ class LitModular(LightningModule):
         for name in self.training_step_log:
             self.log(f"training/{name}", output[name])
 
+        assert "loss" in output
+        return output
+
+    def training_step_end(self, output):
         if self.training_metrics is not None:
             # Some models only return loss in the training mode.
             if self.output_preds_key not in output or self.output_target_key not in output:
@@ -132,8 +136,8 @@ class LitModular(LightningModule):
                     f"You have specified training_metrics, but the model does not return {self.output_preds_key} or {self.output_target_key} during training. You can either nullify training_metrics or configure the model to return {self.output_preds_key} and {self.output_target_key} in the training output."
                 )
             self.training_metrics(output[self.output_preds_key], output[self.output_target_key])
-
-        return output[self.output_loss_key]
+        loss = output.pop(self.output_loss_key)
+        return loss
 
     def training_epoch_end(self, outputs):
         if self.training_metrics is not None:
@@ -155,9 +159,13 @@ class LitModular(LightningModule):
         for name in self.validation_step_log:
             self.log(f"validation/{name}", output[name])
 
+        return output
+
+    def validation_step_end(self, output):
         self.validation_metrics(output[self.output_preds_key], output[self.output_target_key])
 
-        return None
+        # I don't know why this is required to prevent CUDA memory leak in validaiton and test. (Not required in training.)
+        output.clear()
 
     def validation_epoch_end(self, outputs):
         metrics = self.validation_metrics.compute()
@@ -177,9 +185,13 @@ class LitModular(LightningModule):
         for name in self.test_step_log:
             self.log(f"test/{name}", output[name])
 
+        return output
+
+    def test_step_end(self, output):
         self.test_metrics(output[self.output_preds_key], output[self.output_target_key])
 
-        return None
+        # I don't know why this is required to prevent CUDA memory leak in validaiton and test. (Not required in training.)
+        output.clear()
 
     def test_epoch_end(self, outputs):
         metrics = self.test_metrics.compute()


### PR DESCRIPTION
# What does this PR do?

This PR merges `*_step_end` into `*_step` in `LitModular`. This means we no longer need to clear outputs.

This PR depends upon the following:
- [x] #169

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [x] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
