### PR TITLE
Don't lookup non-str keys in `SequentialDict`

### DIFF
--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -158,6 +158,8 @@ class CallWith(torch.nn.Module):
                     f"Module {orig_class} wants arg named '{key}' but only received kwargs: {', '.join(kwargs.keys())}."
                 )
 
+        # For each specified args/kwargs key, lookup its corresponding value in kwargs only if the key is a string.
+        # Otherwise, we just treat the key as a value.
         selected_args = [
             kwargs[key] if isinstance(key, str) else key for key in arg_keys[len(args) :]
         ]

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -112,6 +112,7 @@ class SequentialDict(torch.nn.ModuleDict):
             # Don't pop the first element yet, because it may be used to re-evaluate the model.
             key, module = next(iter(sequence.items()))
 
+            # FIXME: Add better error message
             output = module(step=step, sequence=sequence, **kwargs)
 
             if key in kwargs:
@@ -152,14 +153,16 @@ class CallWith(torch.nn.Module):
         # as it and assume these consume the first len(args) of arg_keys.
         remaining_arg_keys = arg_keys[len(args) :]
 
-        for key in remaining_arg_keys + list(kwarg_keys.values()):
+        # Check to make sure each str exists within kwargs
+        str_kwarg_keys = filter(lambda k: isinstance(k, str), kwarg_keys.values())
+        for key in remaining_arg_keys + list(str_kwarg_keys):
             if key not in kwargs:
                 raise Exception(
                     f"Module {orig_class} wants arg named '{key}' but only received kwargs: {', '.join(kwargs.keys())}."
                 )
 
-        selected_args = [kwargs[key] for key in arg_keys[len(args) :]]
-        selected_kwargs = {key: kwargs[val] for key, val in kwarg_keys.items()}
+        selected_args = [kwargs[key] if isinstance(key, str) else key for key in arg_keys[len(args) :]]
+        selected_kwargs = {key: kwargs[val] if isinstance(val, str) else val for key, val in kwarg_keys.items()}
 
         # FIXME: Add better error message
         ret = self.module(*args, *selected_args, **selected_kwargs)

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -27,7 +27,7 @@ class SequentialDict(torch.nn.ModuleDict):
     <module name>:
         _name_: <return key>
         _call_with_args_: <a list of *args>
-        _return_as_dict: <a list of keys to wrap the returned tuple as a dictionary>
+        _return_as_dict_: <a list of keys to wrap the returned tuple as a dictionary>
         **kwargs
 
     All intermediate output from each module are stored in the dictionary `kwargs` in `forward()`
@@ -86,7 +86,7 @@ class SequentialDict(torch.nn.ModuleDict):
             # The module would be called with these *args.
             arg_keys = module_cfg.pop("_call_with_args_", None)
             # The module would return a dictionary with these keys instead of a tuple.
-            return_keys = module_cfg.pop("_return_as_dict", None)
+            return_keys = module_cfg.pop("_return_as_dict_", None)
             # The module would be called with these **kwargs.
             kwarg_keys = module_cfg
 

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -27,7 +27,7 @@ class SequentialDict(torch.nn.ModuleDict):
     <module name>:
         _name_: <return key>
         _call_with_args_: <a list of *args>
-        _return_as_dict_: <a list of keys to wrap the returned tuple as a dictionary>
+        _return_as_dict: <a list of keys to wrap the returned tuple as a dictionary>
         **kwargs
 
     All intermediate output from each module are stored in the dictionary `kwargs` in `forward()`
@@ -86,7 +86,7 @@ class SequentialDict(torch.nn.ModuleDict):
             # The module would be called with these *args.
             arg_keys = module_cfg.pop("_call_with_args_", None)
             # The module would return a dictionary with these keys instead of a tuple.
-            return_keys = module_cfg.pop("_return_as_dict_", None)
+            return_keys = module_cfg.pop("_return_as_dict", None)
             # The module would be called with these **kwargs.
             kwarg_keys = module_cfg
 

--- a/mart/nn/nn.py
+++ b/mart/nn/nn.py
@@ -161,8 +161,12 @@ class CallWith(torch.nn.Module):
                     f"Module {orig_class} wants arg named '{key}' but only received kwargs: {', '.join(kwargs.keys())}."
                 )
 
-        selected_args = [kwargs[key] if isinstance(key, str) else key for key in arg_keys[len(args) :]]
-        selected_kwargs = {key: kwargs[val] if isinstance(val, str) else val for key, val in kwarg_keys.items()}
+        selected_args = [
+            kwargs[key] if isinstance(key, str) else key for key in arg_keys[len(args) :]
+        ]
+        selected_kwargs = {
+            key: kwargs[val] if isinstance(val, str) else val for key, val in kwarg_keys.items()
+        }
 
         # FIXME: Add better error message
         ret = self.module(*args, *selected_args, **selected_kwargs)


### PR DESCRIPTION
# What does this PR do?

`SequentialDict` always tries to find a corresponding value in a `DotDict`. This changes `SequentialDict` to only lookup values in a `DotDict` when it is a `str`. Other values are passed directly to the underlying module.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [x] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
