### PR TITLE
Remove test on RobustBench.

### DIFF
--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -165,23 +165,6 @@ def test_cifar10_cnn_autoattack_experiment(classification_cfg, tmp_path):
 
 
 @RunIf(sh=True)
-def test_cifar10_robust_bench_experiment(classification_cfg, tmp_path):
-    """Test CIFAR10 Robust Bench experiment."""
-    overrides = classification_cfg["trainer"] + classification_cfg["datamodel"]
-    command = [
-        module,
-        "-m",
-        "experiment=CIFAR10_RobustBench",
-        "hydra.sweep.dir=" + str(tmp_path),
-        "+attack@model.modules.input_adv_test=classification_eps8_pgd10_step1",
-        "optimized_metric=training_metrics/acc",
-        "++datamodule.train_dataset.image_size=[3,32,32]",
-        "++datamodule.train_dataset.num_classes=10",
-    ] + overrides
-    run_sh_command(command)
-
-
-@RunIf(sh=True)
 @pytest.mark.slow
 def test_imagenet_timm_experiment(classification_cfg, tmp_path):
     """Test ImageNet Timm experiment."""


### PR DESCRIPTION
# What does this PR do?

Remove test on RobustBench, because CI always fails to download model weights.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
