### PR TITLE
Allow `LitModular`'s `load_state_dict` to accept a str

### DIFF
--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -5,17 +5,16 @@
 #
 
 import logging
+from operator import attrgetter
+
+import torch
+from pytorch_lightning import LightningModule
+
+from ..nn import SequentialDict
+from ..optim import OptimizerFactory
+from ..utils import flatten_dict
 
 logger = logging.getLogger(__name__)
-
-from operator import attrgetter  # noqa: E402
-
-import torch  # noqa: E402
-from pytorch_lightning import LightningModule  # noqa: E402
-
-from ..nn import SequentialDict  # noqa: E402
-from ..optim import OptimizerFactory  # noqa: E402
-from ..utils import flatten_dict  # noqa: E402
 
 __all__ = ["LitModular"]
 

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -92,10 +92,14 @@ class LitModular(LightningModule):
 
         # Load state dict for specified modules. We flatten it because Hydra
         # commandlines converts dotted paths to nested dictionaries.
+        if isinstance(load_state_dict, str):
+            load_state_dict = {None: load_state_dict}
         load_state_dict = flatten_dict(load_state_dict or {})
 
         for name, path in load_state_dict.items():
-            module = attrgetter(name)(self.model)
+            module = self.model
+            if name is not None:
+                module = attrgetter(name)(module)
             logger.info(f"Loading state_dict {path} for {module.__class__.__name__}...")
             module.load_state_dict(torch.load(path, map_location="cpu"))
 


### PR DESCRIPTION
# What does this PR do?

This PR enables `LitModular`'s `load_state_dict` to take a string that enables loading `state_dict`'s for the internal model.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
