### PR TITLE
Allow PyTorch 2.0.0 in dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">=3.9"
 
 dependencies = [
-  "torch ~= 2.0.1",
+  "torch ~= 2.0.0", # Allow 2.0.0, because Poetry gets incomplete dependency for 2.0.1: https://github.com/python-poetry/poetry/issues/7902
   "torchvision ~= 0.15.2",
   "lightning[extra] ~= 2.0.5", # Full functionality including TensorboardX.
   "pydantic == 1.10.11", # https://github.com/Lightning-AI/lightning/pull/18022/files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.9"
 
 dependencies = [
   "torch ~= 2.0.0", # Allow 2.0.0, because Poetry gets incomplete dependency for 2.0.1: https://github.com/python-poetry/poetry/issues/7902
-  "torchvision ~= 0.15.2",
+  "torchvision ~= 0.15",
   "lightning[extra] ~= 2.0.5", # Full functionality including TensorboardX.
   "pydantic == 1.10.11", # https://github.com/Lightning-AI/lightning/pull/18022/files
   "torchmetrics == 1.0.0",


### PR DESCRIPTION
# What does this PR do?

We need to allow PyTorch 2.0.0, because PyTorch 2.0.1 gives incomplete dependency to Poetry.

https://github.com/pytorch/pytorch/issues/100974
https://github.com/python-poetry/poetry/issues/7902

An alternative solution is to manually add the missing dependency of PyTorch 2.0.1 to your Poetry config.

I also believe the updated dependency (PyTorch>=2.0.0) makes more sense.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
