### PR TITLE
Log gain of all examples instead of unsuccessful examples.

### DIFF
--- a/mart/attack/adversary.py
+++ b/mart/attack/adversary.py
@@ -123,6 +123,9 @@ class Adversary(pl.LightningModule):
         # Use CallWith to dispatch **outputs.
         gain = self.gain_fn(**outputs)
 
+        # Log gain of all examples as a metric for LR scheduler to monitor, and show gain on progress bar.
+        self.log("gain", gain.sum(), prog_bar=True)
+
         # objective_fn is optional, because adversaries may never reach their objective.
         if self.objective_fn is not None:
             found = self.objective_fn(**outputs)
@@ -131,13 +134,7 @@ class Adversary(pl.LightningModule):
             if len(gain.shape) > 0:
                 gain = gain[~found]
 
-        if len(gain.shape) > 0:
-            gain = gain.sum()
-
-        # Log gain as a metric for LR scheduler to monitor, and show gain on progress bar.
-        self.log("gain", gain, prog_bar=True)
-
-        return gain
+        return gain.sum()
 
     def configure_gradient_clipping(
         self, optimizer, gradient_clip_val=None, gradient_clip_algorithm=None


### PR DESCRIPTION
# What does this PR do?

This PR makes `Adversary` log gain of all examples, instead of gain of unsuccessful examples.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
