### PR TITLE
Disable FiftyOne's tracker.

### DIFF
--- a/mart/datamodules/fiftyone.py
+++ b/mart/datamodules/fiftyone.py
@@ -17,6 +17,7 @@ from torchvision.datasets import VisionDataset as VisionDataset_
 logger = logging.getLogger(__name__)
 try:
     # Disable the FiftyOne tracker due to the privacy concern.
+    # Users should delete the following line if they intend to be tracked.
     os.environ["FIFTYONE_DO_NOT_TRACK"] = "1"
     import fiftyone as fo
     import fiftyone.utils.coco as fouc

--- a/mart/datamodules/fiftyone.py
+++ b/mart/datamodules/fiftyone.py
@@ -16,9 +16,10 @@ from torchvision.datasets import VisionDataset as VisionDataset_
 
 logger = logging.getLogger(__name__)
 try:
-    # Disable the FiftyOne tracker due to the privacy concern.
-    # Users should delete the following line if they intend to be tracked.
-    os.environ["FIFTYONE_DO_NOT_TRACK"] = "1"
+    # Disable the FiftyOne tracker by default due to the privacy concern.
+    # Users need to export FIFTYONE_DO_NOT_TRACK=0 if they intend to be tracked.
+    if os.getenv("FIFTYONE_DO_NOT_TRACK") is None:
+        os.environ["FIFTYONE_DO_NOT_TRACK"] = "1"
     import fiftyone as fo
     import fiftyone.utils.coco as fouc
 except ImportError:

--- a/mart/datamodules/fiftyone.py
+++ b/mart/datamodules/fiftyone.py
@@ -16,6 +16,8 @@ from torchvision.datasets import VisionDataset as VisionDataset_
 
 logger = logging.getLogger(__name__)
 try:
+    # Disable the FiftyOne tracker due to the privacy concern.
+    os.environ["FIFTYONE_DO_NOT_TRACK"] = "1"
     import fiftyone as fo
     import fiftyone.utils.coco as fouc
 except ImportError:


### PR DESCRIPTION
# What does this PR do?

This PR disables FiftyOne's tracker. Users need to explicitly set `FIFTYONE_DO_NOT_TRACK=0` if they want to be tracked.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
