### PR TITLE
Add a YAML config file generator

### DIFF
--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -10,12 +10,16 @@ import fire
 from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
 
+DEFAULT_VERSION_BASE = "1.2"
+DEFAULT_CONFIG_DIR = "."
+DEFAULT_CONFIG_NAME = "lightning.yaml"
+
 
 def mart_compose(
     *overrides,
-    version_base: str = "1.2",
-    config_dir: str = "configs",
-    config_name: str = "lightning.yaml",
+    version_base: str = DEFAULT_VERSION_BASE,
+    config_dir: str = DEFAULT_CONFIG_DIR,
+    config_name: str = DEFAULT_CONFIG_NAME,
     export_node: str = None,
 ):
     # Add an absolute path {config_dir} to the search path of configs, preceding those in mart.configs.
@@ -45,9 +49,9 @@ def get_yaml_cfg(cfg, resolve: bool = False):
 
 def main(
     *overrides,
-    version_base: str = "1.2",
-    config_dir: str = "configs",
-    config_name: str = "lightning.yaml",
+    version_base: str = DEFAULT_VERSION_BASE,
+    config_dir: str = DEFAULT_CONFIG_DIR,
+    config_name: str = DEFAULT_CONFIG_NAME,
     export_node: str = None,
     resolve: bool = False,
 ):

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -6,47 +6,15 @@
 
 from __future__ import annotations
 
-import os
-
 import fire
-from hydra import compose, initialize_config_dir
-from omegaconf import OmegaConf
 
-DEFAULT_VERSION_BASE = "1.2"
-DEFAULT_CONFIG_DIR = "."
-DEFAULT_CONFIG_NAME = "lightning.yaml"
-
-
-def mart_compose(
-    *overrides,
-    version_base: str = DEFAULT_VERSION_BASE,
-    config_dir: str = DEFAULT_CONFIG_DIR,
-    config_name: str = DEFAULT_CONFIG_NAME,
-    export_node: str | None = None,
-):
-    # Add an absolute path {config_dir} to the search path of configs, preceding those in mart.configs.
-    if not os.path.isabs(config_dir):
-        config_dir = os.path.abspath(config_dir)
-
-    # hydra.initialize_config_dir() requires an absolute path,
-    # while hydra.initialize() searches paths relatively to mart.
-    with initialize_config_dir(version_base=version_base, config_dir=config_dir):
-        cfg = compose(config_name=config_name, overrides=overrides)
-
-    # Export a sub-tree.
-    if export_node is not None:
-        for key in export_node.split("."):
-            cfg = cfg[key]
-
-    return cfg
-
-
-def get_yaml_cfg(cfg, resolve: bool = False):
-    # Resolve all interpolation in the sub-tree.
-    if resolve:
-        OmegaConf.resolve(cfg)
-
-    return OmegaConf.to_yaml(cfg)
+from .utils.config import (
+    DEFAULT_CONFIG_DIR,
+    DEFAULT_CONFIG_NAME,
+    DEFAULT_VERSION_BASE,
+    compose,
+    get_yaml_cfg,
+)
 
 
 def main(
@@ -57,7 +25,7 @@ def main(
     export_node: str | None = None,
     resolve: bool = False,
 ):
-    cfg = mart_compose(
+    cfg = compose(
         *overrides,
         version_base=version_base,
         config_dir=config_dir,

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -7,13 +7,13 @@
 from __future__ import annotations
 
 import fire
+from omegaconf import OmegaConf
 
 from .utils.config import (
     DEFAULT_CONFIG_DIR,
     DEFAULT_CONFIG_NAME,
     DEFAULT_VERSION_BASE,
     compose,
-    get_yaml_cfg,
 )
 
 
@@ -24,6 +24,7 @@ def main(
     config_name: str = DEFAULT_CONFIG_NAME,
     export_node: str | None = None,
     resolve: bool = False,
+    sort_keys: bool = True,
 ):
     cfg = compose(
         *overrides,
@@ -33,7 +34,7 @@ def main(
         export_node=export_node,
     )
 
-    cfg_yaml = get_yaml_cfg(cfg, resolve=resolve)
+    cfg_yaml = OmegaConf.to_yaml(cfg, resolve=resolve, sort_keys=sort_keys)
 
     # OmegaConf.to_yaml() already ends with `\n`.
     print(cfg_yaml, end="")

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -1,3 +1,9 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import os
 
 import fire

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+from __future__ import annotations
+
 import os
 
 import fire
@@ -20,7 +22,7 @@ def mart_compose(
     version_base: str = DEFAULT_VERSION_BASE,
     config_dir: str = DEFAULT_CONFIG_DIR,
     config_name: str = DEFAULT_CONFIG_NAME,
-    export_node: str = None,
+    export_node: str | None = None,
 ):
     # Add an absolute path {config_dir} to the search path of configs, preceding those in mart.configs.
     if not os.path.isabs(config_dir):
@@ -52,7 +54,7 @@ def main(
     version_base: str = DEFAULT_VERSION_BASE,
     config_dir: str = DEFAULT_CONFIG_DIR,
     config_name: str = DEFAULT_CONFIG_NAME,
-    export_node: str = None,
+    export_node: str | None = None,
     resolve: bool = False,
 ):
     cfg = mart_compose(

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -22,7 +22,8 @@ def mart_compose(
     if not os.path.isabs(config_dir):
         config_dir = os.path.abspath(config_dir)
 
-    # initialize_config_dir() requires an absolute path.
+    # hydra.initialize_config_dir() requires an absolute path,
+    # while hydra.initialize() searches paths relatively to mart.
     with initialize_config_dir(version_base=version_base, config_dir=config_dir):
         cfg = compose(config_name=config_name, overrides=overrides)
 

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -17,7 +17,6 @@ def generate(
     config_dir: str = "configs",
     config_name: str = "lightning.yaml",
     export_node: str = None,
-    export_name: str = "output.yaml",
     resolve: bool = False,
 ):
     # An absolute path {config_dir} is added to the search path of configs, preceding those in mart.configs.
@@ -36,13 +35,8 @@ def generate(
         if resolve:
             OmegaConf.resolve(cfg)
 
-        # Create folders for output if necessary.
-        folder = os.path.dirname(export_name)
-        if folder != "" and not os.path.isdir(folder):
-            os.makedirs(folder)
-
-        OmegaConf.save(config=cfg, f=export_name)
-        print(f"Config file saved to {export_name}")
+        # OmegaConf.to_yaml() already ends with `\n`.
+        print(OmegaConf.to_yaml(cfg), end="")
 
 
 if __name__ == "__main__":

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -11,7 +11,38 @@ from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
 
 
-def generate(
+def mart_compose(
+    *overrides,
+    version_base: str = "1.2",
+    config_dir: str = "configs",
+    config_name: str = "lightning.yaml",
+    export_node: str = None,
+):
+    # Add an absolute path {config_dir} to the search path of configs, preceding those in mart.configs.
+    if not os.path.isabs(config_dir):
+        config_dir = os.path.abspath(config_dir)
+
+    # initialize_config_dir() requires an absolute path.
+    with initialize_config_dir(version_base=version_base, config_dir=config_dir):
+        cfg = compose(config_name=config_name, overrides=overrides)
+
+    # Export a sub-tree.
+    if export_node is not None:
+        for key in export_node.split("."):
+            cfg = cfg[key]
+
+    return cfg
+
+
+def get_yaml_cfg(cfg, resolve: bool = False):
+    # Resolve all interpolation in the sub-tree.
+    if resolve:
+        OmegaConf.resolve(cfg)
+
+    return OmegaConf.to_yaml(cfg)
+
+
+def main(
     *overrides,
     version_base: str = "1.2",
     config_dir: str = "configs",
@@ -19,25 +50,19 @@ def generate(
     export_node: str = None,
     resolve: bool = False,
 ):
-    # An absolute path {config_dir} is added to the search path of configs, preceding those in mart.configs.
-    if not os.path.isabs(config_dir):
-        config_dir = os.path.abspath(config_dir)
+    cfg = mart_compose(
+        *overrides,
+        version_base=version_base,
+        config_dir=config_dir,
+        config_name=config_name,
+        export_node=export_node,
+    )
 
-    with initialize_config_dir(version_base=version_base, config_dir=config_dir):
-        cfg = compose(config_name=config_name, overrides=overrides)
+    cfg_yaml = get_yaml_cfg(cfg, resolve=resolve)
 
-        # Export a sub-tree.
-        if export_node is not None:
-            for key in export_node.split("."):
-                cfg = cfg[key]
-
-        # Resolve all interpolation in the sub-tree.
-        if resolve:
-            OmegaConf.resolve(cfg)
-
-        # OmegaConf.to_yaml() already ends with `\n`.
-        print(OmegaConf.to_yaml(cfg), end="")
+    # OmegaConf.to_yaml() already ends with `\n`.
+    print(cfg_yaml, end="")
 
 
 if __name__ == "__main__":
-    fire.Fire(generate)
+    fire.Fire(main)

--- a/mart/generate_config.py
+++ b/mart/generate_config.py
@@ -1,0 +1,43 @@
+import os
+
+import fire
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+
+def generate(
+    *overrides,
+    version_base: str = "1.2",
+    config_dir: str = "configs",
+    config_name: str = "lightning.yaml",
+    export_node: str = None,
+    export_name: str = "output.yaml",
+    resolve: bool = False,
+):
+    # An absolute path {config_dir} is added to the search path of configs, preceding those in mart.configs.
+    if not os.path.isabs(config_dir):
+        config_dir = os.path.abspath(config_dir)
+
+    with initialize_config_dir(version_base=version_base, config_dir=config_dir):
+        cfg = compose(config_name=config_name, overrides=overrides)
+
+        # Export a sub-tree.
+        if export_node is not None:
+            for key in export_node.split("."):
+                cfg = cfg[key]
+
+        # Resolve all interpolation in the sub-tree.
+        if resolve:
+            OmegaConf.resolve(cfg)
+
+        # Create folders for output if necessary.
+        folder = os.path.dirname(export_name)
+        if folder != "" and not os.path.isdir(folder):
+            os.makedirs(folder)
+
+        OmegaConf.save(config=cfg, f=export_name)
+        print(f"Config file saved to {export_name}")
+
+
+if __name__ == "__main__":
+    fire.Fire(generate)

--- a/mart/utils/__init__.py
+++ b/mart/utils/__init__.py
@@ -1,4 +1,5 @@
 from .adapters import *
+from .config import *
 from .export import *
 from .monkey_patch import *
 from .pylogger import *

--- a/mart/utils/config.py
+++ b/mart/utils/config.py
@@ -10,14 +10,13 @@ import os
 
 from hydra import compose as hydra_compose
 from hydra import initialize_config_dir
-from hydra.utils import instantiate as hydra_instantiate
 from omegaconf import OmegaConf
 
 DEFAULT_VERSION_BASE = "1.2"
 DEFAULT_CONFIG_DIR = "."
 DEFAULT_CONFIG_NAME = "lightning.yaml"
 
-__all__ = ["compose", "instantiate", "get_yaml_cfg"]
+__all__ = ["compose", "get_yaml_cfg"]
 
 
 def compose(
@@ -42,29 +41,6 @@ def compose(
             cfg = cfg[key]
 
     return cfg
-
-
-def instantiate(
-    *overrides,
-    version_base: str = DEFAULT_VERSION_BASE,
-    config_dir: str = DEFAULT_CONFIG_DIR,
-    config_name: str = DEFAULT_CONFIG_NAME,
-    export_node: str | None = None,
-):
-    """Compose and instantiate an object.
-
-    Should be useful in testing configs.
-    """
-    cfg = compose(
-        *overrides,
-        version_base=version_base,
-        config_dir=config_dir,
-        config_name=config_name,
-        export_node=export_node,
-    )
-
-    obj = hydra_instantiate(cfg)
-    return obj
 
 
 def get_yaml_cfg(cfg, resolve: bool = False):

--- a/mart/utils/config.py
+++ b/mart/utils/config.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+from __future__ import annotations
+
+import os
+
+from hydra import compose as hydra_compose
+from hydra import initialize_config_dir
+from hydra.utils import instantiate as hydra_instantiate
+from omegaconf import OmegaConf
+
+DEFAULT_VERSION_BASE = "1.2"
+DEFAULT_CONFIG_DIR = "."
+DEFAULT_CONFIG_NAME = "lightning.yaml"
+
+
+def compose(
+    *overrides,
+    version_base: str = DEFAULT_VERSION_BASE,
+    config_dir: str = DEFAULT_CONFIG_DIR,
+    config_name: str = DEFAULT_CONFIG_NAME,
+    export_node: str | None = None,
+):
+    # Add an absolute path {config_dir} to the search path of configs, preceding those in mart.configs.
+    if not os.path.isabs(config_dir):
+        config_dir = os.path.abspath(config_dir)
+
+    # hydra.initialize_config_dir() requires an absolute path,
+    # while hydra.initialize() searches paths relatively to mart.
+    with initialize_config_dir(version_base=version_base, config_dir=config_dir):
+        cfg = hydra_compose(config_name=config_name, overrides=overrides)
+
+    # Export a sub-tree.
+    if export_node is not None:
+        for key in export_node.split("."):
+            cfg = cfg[key]
+
+    return cfg
+
+
+def instantiate(
+    *overrides,
+    version_base: str = DEFAULT_VERSION_BASE,
+    config_dir: str = DEFAULT_CONFIG_DIR,
+    config_name: str = DEFAULT_CONFIG_NAME,
+    export_node: str | None = None,
+):
+    cfg = compose(
+        *overrides,
+        version_base=version_base,
+        config_dir=config_dir,
+        config_name=config_name,
+        export_node=export_node,
+    )
+
+    obj = hydra_instantiate(cfg)
+    return obj
+
+
+def get_yaml_cfg(cfg, resolve: bool = False):
+    # Resolve all interpolation in the sub-tree.
+    if resolve:
+        OmegaConf.resolve(cfg)
+
+    return OmegaConf.to_yaml(cfg)

--- a/mart/utils/config.py
+++ b/mart/utils/config.py
@@ -10,13 +10,12 @@ import os
 
 from hydra import compose as hydra_compose
 from hydra import initialize_config_dir
-from omegaconf import OmegaConf
 
 DEFAULT_VERSION_BASE = "1.2"
 DEFAULT_CONFIG_DIR = "."
 DEFAULT_CONFIG_NAME = "lightning.yaml"
 
-__all__ = ["compose", "get_yaml_cfg"]
+__all__ = ["compose"]
 
 
 def compose(
@@ -41,11 +40,3 @@ def compose(
             cfg = cfg[key]
 
     return cfg
-
-
-def get_yaml_cfg(cfg, resolve: bool = False):
-    # Resolve all interpolation in the sub-tree.
-    if resolve:
-        OmegaConf.resolve(cfg)
-
-    return OmegaConf.to_yaml(cfg)

--- a/mart/utils/config.py
+++ b/mart/utils/config.py
@@ -17,6 +17,8 @@ DEFAULT_VERSION_BASE = "1.2"
 DEFAULT_CONFIG_DIR = "."
 DEFAULT_CONFIG_NAME = "lightning.yaml"
 
+__all__ = ["compose", "instantiate", "get_yaml_cfg"]
+
 
 def compose(
     *overrides,

--- a/mart/utils/config.py
+++ b/mart/utils/config.py
@@ -51,6 +51,10 @@ def instantiate(
     config_name: str = DEFAULT_CONFIG_NAME,
     export_node: str | None = None,
 ):
+    """Compose and instantiate an object.
+
+    Should be useful in testing configs.
+    """
     cfg = compose(
         *overrides,
         version_base=version_base,


### PR DESCRIPTION
# What does this PR do?

This PR adds a YAML config file generator.

We can generate YAML configs for running MART attacks in external projects. For example,

```shell
python -m mart.generate_config \
--export_node=attack \
+attack=classification_fgsm_linf \
attack.eps=0.5 \
> attack_config.yaml
```

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
