### PR TITLE
Make mask key configurable.

### DIFF
--- a/mart/attack/enforcer.py
+++ b/mart/attack/enforcer.py
@@ -83,10 +83,14 @@ class Integer(Constraint):
 
 
 class Mask(Constraint):
+    def __init__(self, key="perturbable_mask"):
+        super().__init__()
+        self.key = key
+
     def verify(self, input_adv, *, input, target):
         # True/1 is mutable, False/0 is immutable.
         # mask.shape=(H, W)
-        mask = target["perturbable_mask"]
+        mask = target[self.key]
 
         # Immutable boolean mask, True is immutable.
         imt_mask = (1 - mask).bool()

--- a/mart/attack/projector.py
+++ b/mart/attack/projector.py
@@ -154,9 +154,13 @@ class LinfAdditiveRange(Projector):
 
 
 class Mask(Projector):
+    def __init__(self, key="perturbable_mask"):
+        super().__init__()
+        self.key = key
+
     @torch.no_grad()
     def project_(self, perturbation, *, input, target):
-        perturbation.mul_(target["perturbable_mask"])
+        perturbation.mul_(target[self.key])
 
     def __repr__(self):
         return f"{self.__class__.__name__}()"


### PR DESCRIPTION
# What does this PR do?

This PR makes the mask key configurable in the Mask Projector and the Mask Enforcer.

We use the key `perturbable_mask` in MART, but Armory uses `mask` for the same purpose. We should make it configurable.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
