### PR TITLE
Add conversion between PyTorch tensors and Numpy arrays

### DIFF
--- a/mart/transforms/tensor_array.py
+++ b/mart/transforms/tensor_array.py
@@ -29,7 +29,7 @@ def _(obj: list, device=None):
 
 @convert.register
 def _(obj: tuple, device=None):
-    return tuple(convert(obj, device=device))
+    return tuple(convert(item, device=device) for item in obj)
 
 
 @convert.register

--- a/mart/transforms/tensor_array.py
+++ b/mart/transforms/tensor_array.py
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+from functools import singledispatch
+
+import numpy as np
+import torch
+
+
+# A recursive function to convert all np.ndarray in an object to torch.Tensor, or vice versa.
+@singledispatch
+def convert(obj, device=None):
+    """All other types, no change."""
+    return obj
+
+
+@convert.register
+def _(obj: dict, device=None):
+    return {key: convert(value, device=device) for key, value in obj.items()}
+
+
+@convert.register
+def _(obj: list, device=None):
+    return [convert(item, device=device) for item in obj]
+
+
+@convert.register
+def _(obj: tuple, device=None):
+    return tuple(convert(obj, device=device))
+
+
+@convert.register
+def _(obj: np.ndarray, device=None):
+    return torch.tensor(obj, device=device)
+
+
+@convert.register
+def _(obj: torch.Tensor, device=None):
+    return obj.detach().cpu().numpy()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import numpy as np
+import torch
+
+from mart.transforms.tensor_array import convert
+
+
+def test_tensor_array_two_way_convert():
+    tensor_expected = [{"key": (torch.tensor(1.0), 2)}]
+    array_expected = [{"key": (np.array(1.0), 2)}]
+
+    array_result = convert(tensor_expected)
+    assert array_expected == array_result
+
+    tensor_result = convert(array_expected)
+    assert tensor_expected == tensor_result


### PR DESCRIPTION
# What does this PR do?

This PR adds a recursive convertor `mart.transforms.tensor_array.convert` that converts between Numpy arrays and PyTorch tensors hidden in complex data structures.

This is useful when running MART attacks in ARMORY because the Numpy data structure is used in ARMORY.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
