### PR TITLE
Fix adversarial image visualizer with canonical batches

### DIFF
--- a/mart/callbacks/visualizer.py
+++ b/mart/callbacks/visualizer.py
@@ -27,9 +27,9 @@ class PerturbedImageVisualizer(Callback):
             os.makedirs(self.folder)
 
     def on_train_batch_end(self, trainer, model, outputs, batch, batch_idx):
-        # Save input and target for on_train_end
-        self.input = batch["input"]
-        self.target = batch["target"]
+        # Save canonical input and target for on_train_end
+        self.input = batch[0]
+        self.target = batch[1]
 
     def on_train_end(self, trainer, model):
         # FIXME: We should really just save this to outputs instead of recomputing adv_input

--- a/mart/callbacks/visualizer.py
+++ b/mart/callbacks/visualizer.py
@@ -34,8 +34,7 @@ class PerturbedImageVisualizer(Callback):
     def on_train_end(self, trainer, model):
         # FIXME: We should really just save this to outputs instead of recomputing adv_input
         with torch.no_grad():
-            perturbation = model.perturber(input=self.input, target=self.target)
-            adv_input = model.composer(perturbation, input=self.input, target=self.target)
+            adv_input, _target = model(self.input, self.target)
 
         for img, tgt in zip(adv_input, self.target):
             fname = tgt["file_name"]

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -19,19 +19,21 @@ def test_visualizer_run_end(input_data, target_data, perturbation, tmp_path):
     target_list = [target_data]
 
     # simulate an addition perturbation
-    def perturb(input):
+    def perturb(input, target):
         result = [sample + perturbation for sample in input]
-        return result
+        return result, target
 
-    trainer = Mock()
-    model = Mock(composer=Mock(return_value=perturb(input_list)))
-    outputs = Mock()
-    batch = {"input": input_list, "target": target_list}
     adversary = Mock(spec=Adversary, side_effect=perturb)
+    trainer = Mock()
+    outputs = Mock()
+    target_model = Mock()
+
+    # Canonical batch in Adversary.
+    batch = (input_list, target_list, target_model)
 
     visualizer = PerturbedImageVisualizer(folder)
-    visualizer.on_train_batch_end(trainer, model, outputs, batch, 0)
-    visualizer.on_train_end(trainer, model)
+    visualizer.on_train_batch_end(trainer, adversary, outputs, batch, 0)
+    visualizer.on_train_end(trainer, adversary)
 
     # verify that the visualizer created the JPG file
     expected_output_path = folder / target_data["file_name"]


### PR DESCRIPTION
# What does this PR do?

This PR fixes the adversarial image visualizer after canonicalizing adversarial batches.
* Fetch canonical input and target in the adversarial image visualizer.
* Use `Adversary.forward()` to get adversarial examples.
* Fix test.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
