### PR TITLE
Add learning rate schedulers in Adversary

### DIFF
--- a/mart/configs/attack/adaptive_gradient_ascent.yaml
+++ b/mart/configs/attack/adaptive_gradient_ascent.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - /optimization@: adaptive_sgd
+
+optimizer:
+  # Change the optimizer borrowed from training LitModular.
+  maximize: True
+  lr: ${..lr}
+
+lr_scheduler:
+  # The adaptive learning rate scheduler monitors some variable and adapt to it.
+  monitor: ???
+  scheduler:
+    # learning rate divided by 2
+    factor: 0.5
+    # minimum learning rate 1/255
+    min_lr: 1
+    # Set verbose true to debug the learning rate.
+    verbose: true
+    # We usually try to maximize something in Adversary.
+    mode: max
+
+max_iters: ???
+lr: ???

--- a/mart/configs/attack/adversary.yaml
+++ b/mart/configs/attack/adversary.yaml
@@ -6,6 +6,7 @@ _target_: mart.attack.Adversary
 _convert_: all
 optimizer:
   maximize: True
+lr_scheduler: null
 gain: ???
 gradient_modifier: null
 objective: null

--- a/mart/configs/optimization/adaptive_sgd.yaml
+++ b/mart/configs/optimization/adaptive_sgd.yaml
@@ -1,0 +1,11 @@
+# @package model
+defaults:
+  - /optimizer@optimizer: sgd
+  - lr_scheduler/scheduler: reduced_lr_on_plateau
+
+optimizer: ???
+
+lr_scheduler:
+  interval: step
+  frequency: 1
+  monitor: ???

--- a/mart/configs/optimization/lr_scheduler/scheduler/reduced_lr_on_plateau.yaml
+++ b/mart/configs/optimization/lr_scheduler/scheduler/reduced_lr_on_plateau.yaml
@@ -1,0 +1,11 @@
+_target_: torch.optim.lr_scheduler.ReduceLROnPlateau
+_partial_: true
+mode: min
+factor: 0.1
+patience: 10
+threshold: 0.0001
+threshold_mode: rel
+cooldown: 0
+min_lr: 0
+eps: 1e-08
+verbose: false

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -13,6 +13,7 @@ from lightning.pytorch import LightningModule
 from ..nn import SequentialDict
 from ..optim import OptimizerFactory
 from ..utils import flatten_dict
+from ..utils.optimization import configure_optimizers
 
 logger = logging.getLogger(__name__)
 
@@ -108,20 +109,8 @@ class LitModular(LightningModule):
         self.output_target_key = output_target_key
 
     def configure_optimizers(self):
-        config = {}
-        config["optimizer"] = self.optimizer_fn(self.model)
 
-        if self.lr_scheduler is not None:
-            # FIXME: I don't think this actually work correctly, but we don't have an example of an lr_scheduler that is not a DictConfig
-            if "scheduler" in self.lr_scheduler:
-                config["lr_scheduler"] = dict(self.lr_scheduler)
-                config["lr_scheduler"]["scheduler"] = config["lr_scheduler"]["scheduler"](
-                    config["optimizer"]
-                )
-            else:
-                config["lr_scheduler"] = self.lr_scheduler(config["optimizer"])
-
-        return config
+        return configure_optimizers(self.model, self.optimizer_fn, self.lr_scheduler)
 
     def forward(self, **kwargs):
         return self.model(**kwargs)

--- a/mart/utils/optimization.py
+++ b/mart/utils/optimization.py
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+def configure_optimizers(module, optimizer, lr_scheduler):
+    config = {}
+    config["optimizer"] = optimizer(module)
+
+    if lr_scheduler is not None:
+        # FIXME: I don't think this actually work correctly, but we don't have an example of an lr_scheduler that is not a DictConfig
+        if "scheduler" in lr_scheduler:
+            config["lr_scheduler"] = dict(lr_scheduler)
+            config["lr_scheduler"]["scheduler"] = config["lr_scheduler"]["scheduler"](
+                config["optimizer"]
+            )
+        else:
+            config["lr_scheduler"] = lr_scheduler(config["optimizer"])
+
+    return config


### PR DESCRIPTION
# What does this PR do?

This PR adds support to learning rate scheduling in `Adversary`, borrowing the optimization utils from `LitModular`.

This PR also adds `ReduceLROnPlateau` as an example.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
