### PR TITLE
Enhance FiftyOne datamodule on bbox-only datasets

### DIFF
--- a/mart/datamodules/fiftyone.py
+++ b/mart/datamodules/fiftyone.py
@@ -69,10 +69,9 @@ class FiftyOneDataset(VisionDataset_):
         self.ids = self.filtered_dataset.values("id")
 
         # coco_id is a separate and optional field in FiftyOne.
+        self.idx_to_coco_id = range(len(self.filtered_dataset))
         if self.filtered_dataset.has_field("coco_id"):
-            self.coco_ids = self.filtered_dataset.values("coco_id")
-        else:
-            self.coco_ids = range(len(self.filtered_dataset))
+            self.idx_to_coco_id = self.filtered_dataset.values("coco_id")
 
         # set classes
         self.classes = self.filtered_dataset.default_classes
@@ -90,7 +89,7 @@ class FiftyOneDataset(VisionDataset_):
         img = Image.open(image_path).convert("RGB")
 
         target = {}
-        target["image_id"] = self.coco_ids[index]
+        target["image_id"] = self.idx_to_coco_id[index]
         target["file_name"] = image_path.name
         target["annotations"] = []
 

--- a/mart/datamodules/fiftyone.py
+++ b/mart/datamodules/fiftyone.py
@@ -68,6 +68,12 @@ class FiftyOneDataset(VisionDataset_):
         # extract samples' IDs
         self.ids = self.filtered_dataset.values("id")
 
+        # coco_id is a separate and optional field in FiftyOne.
+        if self.filtered_dataset.has_field("coco_id"):
+            self.coco_ids = self.filtered_dataset.values("coco_id")
+        else:
+            self.coco_ids = range(len(self.filtered_dataset))
+
         # set classes
         self.classes = self.filtered_dataset.default_classes
         self.labels_map_rev = {c: i for i, c in enumerate(self.classes)}
@@ -84,7 +90,7 @@ class FiftyOneDataset(VisionDataset_):
         img = Image.open(image_path).convert("RGB")
 
         target = {}
-        target["image_id"] = index
+        target["image_id"] = self.coco_ids[index]
         target["file_name"] = image_path.name
         target["annotations"] = []
 

--- a/mart/transforms/torchvision_ref.py
+++ b/mart/transforms/torchvision_ref.py
@@ -59,12 +59,12 @@ class ConvertCocoPolysToMask:
         classes = torch.tensor(classes, dtype=torch.int64)
 
         masks = None
-        if anno and "segmentation" in anno[0]:
+        if len(anno) > 0 and "segmentation" in anno[0]:
             segmentations = [obj["segmentation"] for obj in anno]
             masks = convert_coco_poly_to_mask(segmentations, h, w)
 
         keypoints = None
-        if anno and "keypoints" in anno[0]:
+        if len(anno) > 0 and "keypoints" in anno[0]:
             keypoints = [obj["keypoints"] for obj in anno]
             keypoints = torch.as_tensor(keypoints, dtype=torch.float32)
             num_keypoints = keypoints.shape[0]

--- a/mart/transforms/torchvision_ref.py
+++ b/mart/transforms/torchvision_ref.py
@@ -58,8 +58,10 @@ class ConvertCocoPolysToMask:
         classes = [obj["category_id"] for obj in anno]
         classes = torch.tensor(classes, dtype=torch.int64)
 
-        segmentations = [obj["segmentation"] for obj in anno]
-        masks = convert_coco_poly_to_mask(segmentations, h, w)
+        masks = None
+        if anno and "segmentation" in anno[0]:
+            segmentations = [obj["segmentation"] for obj in anno]
+            masks = convert_coco_poly_to_mask(segmentations, h, w)
 
         keypoints = None
         if anno and "keypoints" in anno[0]:
@@ -72,14 +74,16 @@ class ConvertCocoPolysToMask:
         keep = (boxes[:, 3] > boxes[:, 1]) & (boxes[:, 2] > boxes[:, 0])
         boxes = boxes[keep]
         classes = classes[keep]
-        masks = masks[keep]
+        if masks is not None:
+            masks = masks[keep]
         if keypoints is not None:
             keypoints = keypoints[keep]
 
         target = {}
         target["boxes"] = boxes
         target["labels"] = classes
-        target["masks"] = masks
+        if masks is not None:
+            target["masks"] = masks
         target["image_id"] = image_id
         target["file_name"] = file_name
         if keypoints is not None:


### PR DESCRIPTION
# What does this PR do?

This PR enhances the FiftyOne datamodule.
* Add support to COCO-format datasets with bounding box annotations only, without segmentation annotations (e.g. ARMORY experimental results.)
* Add support to COCO id in datasets, so that we can add model predictions to FiftyOne datasets afterwards.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
