### PR TITLE
Upgrade flake8 to 7.0.0 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
 
   # python check (PEP8), programming errors and code complexity
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         # ignore E203 because black is used for formatting.

--- a/mart/utils/export.py
+++ b/mart/utils/export.py
@@ -141,7 +141,7 @@ def _get_coco_format_annotations(
                     f"Invalid input box of sample {image_id}, element {k} (expected 4 values, got {len(image_box)})"
                 )
 
-            if type(image_label) != int:
+            if not isinstance(image_label, int):
                 raise ValueError(
                     f"Invalid input class of sample {image_id}, element {k}"
                     f" (expected value of type integer, got type {type(image_label)})"
@@ -155,7 +155,7 @@ def _get_coco_format_annotations(
             }
             if scores is not None:
                 score = scores[i][k].cpu().tolist()
-                if type(score) != float:
+                if not isinstance(score, float):
                     raise ValueError(
                         f"Invalid input score of sample {image_id}, element {k}"
                         f" (expected value of type float, got type {type(score)})"


### PR DESCRIPTION
# What does this PR do?

The current flake8 6.0.0 we use in pre-commit requires space after `:` in strings when running in Python 3.12. So we upgrade to the latest 7.0.0.

flake8 7.0.0 does not allow comparing `type(obj)`, so we changed it to `isinstance(obj, *)`.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
