### PR TITLE
Upgrade pydantic to avoid CVE-2024-3772

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "torch >= 2.0.1",
   "torchvision >= 0.15.2",
   "lightning[extra] ~= 2.0.5", # Full functionality including TensorboardX.
-  "pydantic == 1.10.11", # https://github.com/Lightning-AI/lightning/pull/18022/files
+  "pydantic == 1.10.14", # https://github.com/Lightning-AI/lightning/pull/18022/files
   "torchmetrics == 1.0.1",
   "numpy == 1.23.5", # https://github.com/pytorch/pytorch/issues/91516
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes vuln in https://nvd.nist.gov/vuln/detail/CVE-2024-3772

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [x] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
