### PR TITLE
Make dependencies flexible with optional groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[developer]
+          pip install -e .[core,vision,developer]
 
       - name: List dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[core,vision,developer]
+          pip install -e .[full]
 
       - name: List dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[core,vision,developer]
+          pip install -e .[full]
 
       - name: Run tests and collect coverage
         run: pytest --cov mart

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
 
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[developer]
+          pip install -e .[core,vision,developer]
 
       - name: Run tests and collect coverage
         run: pytest --cov mart

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
 
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@
 ### Using pip
 
 ```bash
-pip install mart[core,vision]@https://github.com/IntelLabs/MART/archive/refs/tags/<VERSION>.zip
+pip install mart[full]@https://github.com/IntelLabs/MART/archive/refs/tags/<VERSION>.zip
 ```
 
 Replace `<VERSION>` with the MART's version you want to install. For example:
 
 ```bash
-pip install mart[core,vision]@https://github.com/IntelLabs/MART/archive/refs/tags/v0.2.1.zip
+pip install mart[full]@https://github.com/IntelLabs/MART/archive/refs/tags/v0.2.1.zip
 ```
 
 ### Manual installation
@@ -52,7 +52,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # Install Modular Adversarial Robustness Toolkit, if you plan to create your own `configs` folder elsewhere.
-pip install -e .[core,vision,developer]
+pip install -e .[full]
 
 # [OPTIONAL] install pre-commit hooks
 # this will trigger the pre-commit checks in each `git commit` command.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@
 ### Using pip
 
 ```bash
-pip install https://github.com/IntelLabs/MART/archive/refs/tags/<VERSION>.zip
+pip install mart[core,vision]@https://github.com/IntelLabs/MART/archive/refs/tags/<VERSION>.zip
 ```
 
 Replace `<VERSION>` with the MART's version you want to install. For example:
 
 ```bash
-pip install https://github.com/IntelLabs/MART/archive/refs/tags/v0.2.1.zip
+pip install mart[core,vision]@https://github.com/IntelLabs/MART/archive/refs/tags/v0.2.1.zip
 ```
 
 ### Manual installation
@@ -52,7 +52,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # Install Modular Adversarial Robustness Toolkit, if you plan to create your own `configs` folder elsewhere.
-pip install -e .
+pip install -e .[core,vision,developer]
 
 # [OPTIONAL] install pre-commit hooks
 # this will trigger the pre-commit checks in each `git commit` command.

--- a/examples/carla_overhead_object_detection/requirements.txt
+++ b/examples/carla_overhead_object_detection/requirements.txt
@@ -1,1 +1,1 @@
-mart[core,vision] @ git+https://github.com/IntelLabs/MART.git
+mart[full] @ git+https://github.com/IntelLabs/MART.git

--- a/examples/carla_overhead_object_detection/requirements.txt
+++ b/examples/carla_overhead_object_detection/requirements.txt
@@ -1,1 +1,1 @@
-mart @ git+https://github.com/IntelLabs/MART.git
+mart[core,vision] @ git+https://github.com/IntelLabs/MART.git

--- a/examples/robust_bench/requirements.txt
+++ b/examples/robust_bench/requirements.txt
@@ -1,2 +1,2 @@
-mart @ git+https://github.com/IntelLabs/MART.git
+mart[full] @ git+https://github.com/IntelLabs/MART.git
 robustbench @ git+https://github.com/RobustBench/robustbench.git@9a590683b7daecf963244dea402529f0d728c727

--- a/mart/__init__.py
+++ b/mart/__init__.py
@@ -1,3 +1,11 @@
-import importlib.metadata
+import importlib
+
+from mart import attack as attack
+from mart import datamodules as datamodules
+from mart import models as models
+from mart import nn as nn
+from mart import optim as optim
+from mart import transforms as transforms
+from mart import utils as utils
 
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/mart/__init__.py
+++ b/mart/__init__.py
@@ -1,11 +1,3 @@
-import importlib
-
-from mart import attack as attack
-from mart import datamodules as datamodules
-from mart import models as models
-from mart import nn as nn
-from mart import optim as optim
-from mart import transforms as transforms
-from mart import utils as utils
+import importlib.metadata
 
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/mart/utils/imports.py
+++ b/mart/utils/imports.py
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+from importlib.util import find_spec
+
+
+def has(module_name):
+    return find_spec(module_name) is not None
+
+
+_HAS_FIFTYONE = has("fiftyone")
+_HAS_TORCHVISION = has("torchvision")
+_HAS_TIMM = has("timm")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,11 @@ developer = [
   "protobuf==3.20.0"
 ]
 
+# Include every dependencies except the loggers, to avoid lengthy dependency resolution.
+# It is rare that a user needs more than one logger.
+# lightning[extra] already includes TensorboardX
 full = [
-  "mart[core,vision,objdet,loggers,developer]",
+  "mart[core,vision,objdet,developer]",
 ]
 
 extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,32 +11,14 @@ authors = [
 requires-python = ">=3.9"
 
 dependencies = [
-  "torch >= 2.0.1",
-  "torchvision >= 0.15.2",
-  "lightning[extra] ~= 2.0.5", # Full functionality including TensorboardX.
-  "pydantic == 1.10.14", # https://github.com/Lightning-AI/lightning/pull/18022/files
-  "torchmetrics == 1.0.1",
-  "numpy == 1.23.5", # https://github.com/pytorch/pytorch/issues/91516
-
   # --------- hydra --------- #
   "hydra-core ~= 1.2.0",
   "hydra-colorlog ~= 1.2.0",
   "hydra-optuna-sweeper ~= 1.2.0",
 
-  # --------- loggers --------- #
-  # wandb
-  # neptune-client
-  # mlflow
-  # comet-ml
-
-  # --------- others --------- #
+  # --------- basics --------- #
   "pyrootutils ~= 1.0.4",      # standardizing the project root setup
   "rich ~= 12.6.0",            # beautiful text formatting in terminal
-  "timm ~= 0.6.11",            # pytorch image models
-
-  # ----- object detection----- #
-  "pycocotools ~= 2.0.5",
-
   "fire == 0.5.0",
 ]
 
@@ -47,6 +29,36 @@ Source = "https://github.com/IntelLabs/MART"
 mart = "mart.__main__:main"
 
 [project.optional-dependencies]
+
+# These are required dependencies, but we make it flexible for users to adjust.
+core = [
+  "torch >= 2.0.1",
+  # TODO: Move torchvision to the optional vision group, and make optional tests locally, but required tests on CI.
+  "torchvision >= 0.15.2",
+  # TODO: Move pycocotools to the optional objdet group, and make optional tests.
+  "pycocotools ~= 2.0.5",      # data format for object detection.
+  "lightning[extra] ~= 2.0.5", # Full functionality including TensorboardX.
+  "torchmetrics == 1.0.1",
+  # TODO: Remove pydantic and numpy constraints with newer lightning.
+  "pydantic == 1.10.14",       # https://github.com/Lightning-AI/lightning/pull/18022/files
+  "numpy == 1.23.5",           # https://github.com/pytorch/pytorch/issues/91516
+]
+
+vision = [
+  "timm ~= 0.6.11",            # pytorch image models
+]
+
+objdet = [
+  "fiftyone ~= 0.21.4",        # visualization for object detection
+]
+
+loggers = [
+  "wandb",
+  "neptune-client",
+  "mlflow",
+  "comet-ml",
+]
+
 developer = [
   "pre-commit ~= 2.20.0",      # hooks for applying linters on commit
   "pytest ~= 7.2.0",           # tests
@@ -54,10 +66,6 @@ developer = [
   "wheel",                     # support setup.py
   "pytest-cov[toml]",
   "protobuf==3.20.0"
-]
-
-fiftyone = [
-  "fiftyone ~= 0.21.4",
 ]
 
 extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,8 @@ developer = [
   "protobuf==3.20.0"
 ]
 
-# Include every dependencies except the loggers, to avoid lengthy dependency resolution.
-# It is rare that a user needs more than one logger.
-# lightning[extra] already includes TensorboardX
 full = [
-  "mart[core,vision,objdet,developer]",
+  "mart[core,vision,objdet,loggers,developer]",
 ]
 
 extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,14 @@ objdet = [
   "fiftyone ~= 0.21.4",        # visualization for object detection
 ]
 
+# Comment out loggers to avoid lengthy dependency resolution.
+# It is rare that users need more than one logger.
+# And lightning[extra] already includes TensorboardX.
 loggers = [
-  "wandb",
-  "neptune",
-  "mlflow",
-  "comet-ml",
+#  "wandb",
+#  "neptune",
+#  "mlflow",
+#  "comet-ml",
 ]
 
 developer = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ developer = [
   "protobuf==3.20.0"
 ]
 
+full = [
+  "mart[core,vision,objdet,loggers,developer]",
+]
+
 extras = [
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ objdet = [
 
 loggers = [
   "wandb",
-  "neptune-client",
+  "neptune",
   "mlflow",
   "comet-ml",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from hydra import compose, initialize
 from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
+from .test_utils import _IN_CI
+
 root = Path(os.getcwd())
 pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
 
@@ -29,7 +31,7 @@ experiments_require_torchvision_and_timm = [
     "ImageNet_Timm",
 ]
 
-if os.getenv("CI") == "true":
+if _IN_CI:
     # Test all experiments on CI
     experiments_names = experiments_require_torchvision + experiments_require_torchvision_and_timm
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,14 +17,30 @@ from omegaconf import DictConfig, open_dict
 root = Path(os.getcwd())
 pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
 
-experiments_names = [
+experiments_require_torchvision = [
     "CIFAR10_CNN",
     "CIFAR10_CNN_Adv",
-    "ImageNet_Timm",
     "COCO_TorchvisionFasterRCNN",
     "COCO_TorchvisionFasterRCNN_Adv",
     "COCO_TorchvisionRetinaNet",
 ]
+
+experiments_require_torchvision_and_timm = [
+    "ImageNet_Timm",
+]
+
+if os.getenv("CI") == "true":
+    # Test all experiments on CI
+    experiments_names = experiments_require_torchvision + experiments_require_torchvision_and_timm
+else:
+    # Only test experiments with installed packages in local environment.
+    from mart.utils.imports import _HAS_TIMM, _HAS_TORCHVISION
+
+    experiments_names = []
+    if _HAS_TORCHVISION:
+        experiments_names += experiments_require_torchvision
+    if _HAS_TIMM and _HAS_TORCHVISION:
+        experiments_names += experiments_require_torchvision_and_timm
 
 
 # Loads the configuration file from a given experiment

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -9,6 +9,8 @@ from tests.helpers.dataset_generator import FakeCOCODataset
 from tests.helpers.run_if import RunIf
 from tests.helpers.run_sh_command import run_sh_command
 
+from .test_utils import _IN_CI
+
 module = "mart"
 
 coco_ds = {
@@ -107,7 +109,7 @@ def test_cifar10_cnn_experiment(classification_cfg, tmp_path):
 
 @RunIf(sh=True)
 @pytest.mark.slow
-@pytest.mark.skipif(not _HAS_TIMM, reason="test requires that timm is installed")
+@pytest.mark.skipif(not _IN_CI and not _HAS_TIMM, reason="test requires that timm is installed")
 def test_imagenet_timm_experiment(classification_cfg, tmp_path):
     """Test ImageNet Timm experiment."""
     overrides = classification_cfg["trainer"] + classification_cfg["datamodel"]

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -4,6 +4,7 @@ from typing import Dict
 import pytest
 from hydra.core.global_hydra import GlobalHydra
 
+from mart.utils.imports import _HAS_TIMM
 from tests.helpers.dataset_generator import FakeCOCODataset
 from tests.helpers.run_if import RunIf
 from tests.helpers.run_sh_command import run_sh_command
@@ -106,6 +107,7 @@ def test_cifar10_cnn_experiment(classification_cfg, tmp_path):
 
 @RunIf(sh=True)
 @pytest.mark.slow
+@pytest.mark.skipif(not _HAS_TIMM, reason="test requires that timm is installed")
 def test_imagenet_timm_experiment(classification_cfg, tmp_path):
     """Test ImageNet Timm experiment."""
     overrides = classification_cfg["trainer"] + classification_cfg["datamodel"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+import os
+
 import pytest
 
 from mart.utils import flatten_dict
@@ -18,3 +20,10 @@ def test_flatten_dict_key_collision():
     d = {"a": 1, "b": {"c": 2, "d": 3}, "b.c": 4}
     with pytest.raises(KeyError):
         flatten_dict(d)
+
+
+def in_ci():
+    return os.getenv("CI") == "true"
+
+
+_IN_CI = in_ci()


### PR DESCRIPTION
# What does this PR do?

This PR moves many required dependencies to the optional "core" and "vision" group, which allows users to manage the dependency manually when integrating MART into their existing projects.

In the future, we should move vision-related dependencies from "core" to "vision", because users who only want to work on audio adversarial examples should not need to install vision components.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
