### PR TITLE
Skip object detection tests if pycocotools is not installed.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from hydra import compose, initialize
 from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
-from mart.utils.imports import _HAS_TIMM, _HAS_TORCHVISION
+from mart.utils.imports import _HAS_PYCOCOTOOLS, _HAS_TIMM, _HAS_TORCHVISION
 
 root = Path(os.getcwd())
 pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
@@ -22,6 +22,9 @@ pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
 experiments_require_torchvision = [
     "CIFAR10_CNN",
     "CIFAR10_CNN_Adv",
+]
+
+experiments_require_torchvision_pycocotools = [
     "COCO_TorchvisionFasterRCNN",
     "COCO_TorchvisionFasterRCNN_Adv",
     "COCO_TorchvisionRetinaNet",
@@ -35,6 +38,8 @@ experiments_require_torchvision_and_timm = [
 experiments_names = []
 if _HAS_TORCHVISION:
     experiments_names += experiments_require_torchvision
+if _HAS_TORCHVISION and _HAS_PYCOCOTOOLS:
+    experiments_names += experiments_require_torchvision_pycocotools
 if _HAS_TIMM and _HAS_TORCHVISION:
     experiments_names += experiments_require_torchvision_and_timm
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -4,7 +4,7 @@ from typing import Dict
 import pytest
 from hydra.core.global_hydra import GlobalHydra
 
-from mart.utils.imports import _HAS_TIMM, _HAS_TORCHVISION
+from mart.utils.imports import _HAS_PYCOCOTOOLS, _HAS_TIMM, _HAS_TORCHVISION
 from tests.helpers.dataset_generator import FakeCOCODataset
 from tests.helpers.run_if import RunIf
 from tests.helpers.run_sh_command import run_sh_command
@@ -131,7 +131,10 @@ def test_imagenet_timm_experiment(classification_cfg, tmp_path):
 
 @RunIf(sh=True)
 @pytest.mark.slow
-@pytest.mark.skipif(not _HAS_TORCHVISION, reason="test requires that torchvision is installed")
+@pytest.mark.skipif(
+    not _HAS_TORCHVISION or not _HAS_PYCOCOTOOLS,
+    reason="test requires that torchvision and pycocotools are installed",
+)
 def test_coco_fasterrcnn_experiment(coco_cfg, tmp_path):
     """Test TorchVision FasterRCNN experiment."""
     overrides = coco_cfg["trainer"] + coco_cfg["datamodel"]
@@ -147,7 +150,10 @@ def test_coco_fasterrcnn_experiment(coco_cfg, tmp_path):
 
 @RunIf(sh=True)
 @pytest.mark.slow
-@pytest.mark.skipif(not _HAS_TORCHVISION, reason="test requires that torchvision is installed")
+@pytest.mark.skipif(
+    not _HAS_TORCHVISION or not _HAS_PYCOCOTOOLS,
+    reason="test requires that torchvision and pycocotools are installed",
+)
 def test_coco_fasterrcnn_adv_experiment(coco_cfg, tmp_path):
     """Test TorchVision FasterRCNN Adv experiment."""
     overrides = coco_cfg["trainer"] + coco_cfg["datamodel"]
@@ -163,7 +169,10 @@ def test_coco_fasterrcnn_adv_experiment(coco_cfg, tmp_path):
 
 @RunIf(sh=True)
 @pytest.mark.slow
-@pytest.mark.skipif(not _HAS_TORCHVISION, reason="test requires that torchvision is installed")
+@pytest.mark.skipif(
+    not _HAS_TORCHVISION or not _HAS_PYCOCOTOOLS,
+    reason="test requires that torchvision and pycocotools  installed",
+)
 def test_coco_retinanet_experiment(coco_cfg, tmp_path):
     """Test TorchVision RetinaNet experiment."""
     overrides = coco_cfg["trainer"] + coco_cfg["datamodel"]


### PR DESCRIPTION
# What does this PR do?

This PR is a supplement to #255

Now we can pass or skip all tests locally with these installation options:

`pip install -e .[core,developer]`
`pip install -e .[core,vision,developer]`
`pip install -e .[core,vision,objdet,developer]`

Note that we install all dependency in CI so no test is skipped in CI.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
