### PR TITLE
Hydra>1.2 compabitility

### DIFF
--- a/mart/__main__.py
+++ b/mart/__main__.py
@@ -25,7 +25,7 @@ root = os.getcwd()
 pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
 
 config_path = os.path.join(root, "configs")
-if not config_path.exists():
+if not os.path.exists(config_path):
     log.warning(f"No config directory found at {config_path}!")
     config_path = "configs"
 

--- a/mart/__main__.py
+++ b/mart/__main__.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-from pathlib import Path
 
 import hydra
 import pyrootutils
@@ -20,10 +19,12 @@ log = utils.get_pylogger(__name__)
 # adds root dir to the PYTHONPATH (so this file can be run from any place)
 # https://github.com/ashleve/pyrootutils
 # FIXME: Get rid of pyrootutils if we don't infer config.paths.root from PROJECT_ROOT.
-root = Path(os.getcwd())
+# Hydra does not support Posix path after 1.2.0: https://github.com/facebookresearch/hydra/commit/53d07f56a272485cc81596d23aad33e18e007091
+# Use string path instead.
+root = os.getcwd()
 pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
 
-config_path = root / "configs"
+config_path = os.path.join(root, "configs")
 if not config_path.exists():
     log.warning(f"No config directory found at {config_path}!")
     config_path = "configs"

--- a/mart/__main__.py
+++ b/mart/__main__.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 import hydra
 import pyrootutils
@@ -19,18 +20,16 @@ log = utils.get_pylogger(__name__)
 # adds root dir to the PYTHONPATH (so this file can be run from any place)
 # https://github.com/ashleve/pyrootutils
 # FIXME: Get rid of pyrootutils if we don't infer config.paths.root from PROJECT_ROOT.
-# Hydra does not support Posix path after 1.2.0: https://github.com/facebookresearch/hydra/commit/53d07f56a272485cc81596d23aad33e18e007091
-# Use string path instead.
-root = os.getcwd()
+root = Path(os.getcwd())
 pyrootutils.set_root(path=root, dotenv=True, pythonpath=True)
 
-config_path = os.path.join(root, "configs")
-if not os.path.exists(config_path):
+config_path = root / "configs"
+if not config_path.exists():
     log.warning(f"No config directory found at {config_path}!")
     config_path = "configs"
 
 
-@hydra.main(version_base="1.2", config_path=config_path, config_name="lightning.yaml")
+@hydra.main(version_base="1.2", config_path=str(config_path), config_name="lightning.yaml")
 def main(cfg: DictConfig) -> float:
 
     if cfg.resume is None and ("datamodule" not in cfg or "model" not in cfg):


### PR DESCRIPTION
# What does this PR do?

This PR changes the `PoxisPath` to `str` path to be compatible with hydra-core>1.2, which assumes path as a string.

The breaking change in Hydra is in https://github.com/facebookresearch/hydra/commit/53d07f56a272485cc81596d23aad33e18e007091

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] `pytest`
- [x] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
