### PR TITLE
Add `UniversalPerturber` and a config template.

### DIFF
--- a/mart/attack/perturber.py
+++ b/mart/attack/perturber.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Sequence
 
 import torch
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
@@ -16,7 +16,7 @@ from .projector import Projector
 if TYPE_CHECKING:
     from .initializer import Initializer
 
-__all__ = ["Perturber"]
+__all__ = ["Perturber", "UniversalPerturber"]
 
 
 class Perturber(torch.nn.Module):
@@ -99,3 +99,26 @@ class Perturber(torch.nn.Module):
         self.projector_(self.perturbation, **batch)
 
         return self.perturbation
+
+
+class UniversalPerturber(Perturber):
+    """The perturbation is shared by all data batches, so we don't duplicate the shape of any
+    batch."""
+
+    def __init__(
+        self,
+        *,
+        shape: Sequence[int],
+        initializer: Initializer,
+        projector: Projector | None = None,
+    ):
+        super().__init__(initializer=initializer, projector=projector)
+
+        # We just configure the perturbation here. No need to invoke configure_perturbation() externally.
+        self.configure_perturbation(shape)
+
+    def configure_perturbation(self, shape: Sequence[int]):
+        perturbation = torch.empty(shape, dtype=torch.float, requires_grad=True)
+        self.perturbation = torch.nn.Parameter(perturbation)
+        # Always initialize the perturbation.
+        self.initializer_(self.perturbation)

--- a/mart/attack/perturber.py
+++ b/mart/attack/perturber.py
@@ -115,9 +115,14 @@ class UniversalPerturber(Perturber):
         super().__init__(initializer=initializer, projector=projector)
 
         # We just configure the perturbation here. No need to invoke configure_perturbation() externally.
-        self.configure_perturbation(shape)
+        self._configure_perturbation(shape)
 
-    def configure_perturbation(self, shape: Sequence[int]):
+    def configure_perturbation(self, input: torch.Tensor | Iterable[torch.Tensor]):
+        raise NotImplementedError(
+            "We don't (repeatedly) configure the universal perturbation with input."
+        )
+
+    def _configure_perturbation(self, shape: Sequence[int]):
         perturbation = torch.empty(shape, dtype=torch.float, requires_grad=True)
         self.perturbation = torch.nn.Parameter(perturbation)
         # Always initialize the perturbation.

--- a/mart/configs/attack/composer/perturber/universal.yaml
+++ b/mart/configs/attack/composer/perturber/universal.yaml
@@ -1,0 +1,5 @@
+_target_: mart.attack.UniversalPerturber
+shape: ???
+initializer: ???
+# Avoid null projector here due to the chance of overriding projectors defined in other config files.
+projector: ???


### PR DESCRIPTION
# What does this PR do?

This PR adds `UniversalPerturber` for training universal perturbations on a dataset.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
