### PR TITLE
Add an option Uniform.round to round the initial numbers.

### DIFF
--- a/mart/attack/initializer/base.py
+++ b/mart/attack/initializer/base.py
@@ -40,13 +40,16 @@ class Constant(Initializer):
 
 
 class Uniform(Initializer):
-    def __init__(self, min: int | float, max: int | float):
+    def __init__(self, min: int | float, max: int | float, round: False):
         self.min = min
         self.max = max
+        self.round = round
 
     @torch.no_grad()
     def initialize_(self, parameter: torch.Tensor) -> None:
         torch.nn.init.uniform_(parameter, self.min, self.max)
+        if self.round:
+            parameter.round_()
 
 
 class UniformLp(Initializer):

--- a/mart/configs/attack/composer/perturber/initializer/uniform.yaml
+++ b/mart/configs/attack/composer/perturber/initializer/uniform.yaml
@@ -1,3 +1,4 @@
 _target_: mart.attack.initializer.Uniform
 min: ???
 max: ???
+round: false


### PR DESCRIPTION
# What does this PR do?

This PR allows users to initialize perturbations as integers (e.g. [0, 255] pixel value).

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
