### PR TITLE
Allow Composer to return intermediate representations.

### DIFF
--- a/mart/configs/attack/composer/default.yaml
+++ b/mart/configs/attack/composer/default.yaml
@@ -2,6 +2,7 @@ defaults:
   - perturber: default
 
 _target_: mart.attack.Composer
+return_final_output_only: true
 modules:
   ???
   # Example: additive, mask, overlay


### PR DESCRIPTION
# What does this PR do?

This PR allows users to expose intermediate reprensentations of `Composer`, so that they can visualize the composition process later.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
