### PR TITLE
Add LitModular.gradient_modifier

### DIFF
--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -25,6 +25,7 @@ class LitModular(LightningModule):
         self,
         modules,
         optimizer,
+        gradient_modifier=None,
         lr_scheduler=None,
         training_sequence=None,
         training_step_log=None,
@@ -71,6 +72,7 @@ class LitModular(LightningModule):
             # Set bias_decay and norm_decay to 0.
             self.optimizer_fn = OptimizerFactory(self.optimizer_fn)
 
+        self.gradient_modifier = gradient_modifier
         self.lr_scheduler = lr_scheduler
 
         # Be backwards compatible by turning list into dict where each item is its own key-value
@@ -111,6 +113,16 @@ class LitModular(LightningModule):
     def configure_optimizers(self):
 
         return configure_optimizers(self.model, self.optimizer_fn, self.lr_scheduler)
+
+    def configure_gradient_clipping(
+        self, optimizer, gradient_clip_val=None, gradient_clip_algorithm=None
+    ):
+        # Configuring gradient clipping in pl.Trainer is still useful, so use it.
+        super().configure_gradient_clipping(optimizer, gradient_clip_val, gradient_clip_algorithm)
+
+        if self.gradient_modifier:
+            for group in optimizer.param_groups:
+                self.gradient_modifier(group["params"])
 
     def forward(self, **kwargs):
         return self.model(**kwargs)


### PR DESCRIPTION
This PR copies the usage of `gradient_modifier` from `Adversary` to `LitModular` to enable training universal perturbations.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [ ] The title is **self-explanatory** and the description **concisely** explains the PR
- [ ] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [ ] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
