### PR TITLE
Add support to the dictionary batch in LitModular.

### DIFF
--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -6,6 +6,7 @@
 
 import logging
 from operator import attrgetter
+from typing import Sequence
 
 import torch
 from lightning.pytorch import LightningModule
@@ -127,9 +128,8 @@ class LitModular(LightningModule):
     def training_step(self, batch, batch_idx):
         # FIXME: Would be much nicer if batch is always a dictionary!
         # We are going to feed the raw batch of a dictionary to self.model, but also making it backward-compatible with the tuple batch format.
-        if isinstance(batch, dict):
-            input = target = None
-        else:
+        input = target = None
+        if isinstance(batch, Sequence) and len(batch) == 2:
             input, target = batch
         output = self(input=input, target=target, batch=batch, model=self.model, step="training")
 
@@ -164,9 +164,8 @@ class LitModular(LightningModule):
     #
     def validation_step(self, batch, batch_idx):
         # FIXME: Would be much nicer if batch was a dict!
-        if isinstance(batch, dict):
-            input = target = None
-        else:
+        input = target = None
+        if isinstance(batch, Sequence) and len(batch) == 2:
             input, target = batch
         output = self(input=input, target=target, batch=batch, model=self.model, step="validation")
 
@@ -189,9 +188,8 @@ class LitModular(LightningModule):
     #
     def test_step(self, batch, batch_idx):
         # FIXME: Would be much nicer if batch was a dict!
-        if isinstance(batch, dict):
-            input = target = None
-        else:
+        input = target = None
+        if isinstance(batch, Sequence) and len(batch) == 2:
             input, target = batch
         output = self(input=input, target=target, batch=batch, model=self.model, step="test")
 

--- a/mart/models/modular.py
+++ b/mart/models/modular.py
@@ -125,9 +125,13 @@ class LitModular(LightningModule):
     # Training
     #
     def training_step(self, batch, batch_idx):
-        # FIXME: Would be much nicer if batch was a dict!
-        input, target = batch
-        output = self(input=input, target=target, model=self.model, step="training")
+        # FIXME: Would be much nicer if batch is always a dictionary!
+        # We are going to feed the raw batch of a dictionary to self.model, but also making it backward-compatible with the tuple batch format.
+        if isinstance(batch, dict):
+            input = target = None
+        else:
+            input, target = batch
+        output = self(input=input, target=target, batch=batch, model=self.model, step="training")
 
         for log_name, output_key in self.training_step_log.items():
             self.log(f"training/{log_name}", output[output_key])
@@ -160,8 +164,11 @@ class LitModular(LightningModule):
     #
     def validation_step(self, batch, batch_idx):
         # FIXME: Would be much nicer if batch was a dict!
-        input, target = batch
-        output = self(input=input, target=target, model=self.model, step="validation")
+        if isinstance(batch, dict):
+            input = target = None
+        else:
+            input, target = batch
+        output = self(input=input, target=target, batch=batch, model=self.model, step="validation")
 
         for log_name, output_key in self.validation_step_log.items():
             self.log(f"validation/{log_name}", output[output_key])
@@ -182,8 +189,11 @@ class LitModular(LightningModule):
     #
     def test_step(self, batch, batch_idx):
         # FIXME: Would be much nicer if batch was a dict!
-        input, target = batch
-        output = self(input=input, target=target, model=self.model, step="test")
+        if isinstance(batch, dict):
+            input = target = None
+        else:
+            input, target = batch
+        output = self(input=input, target=target, batch=batch, model=self.model, step="test")
 
         for log_name, output_key in self.test_step_log.items():
             self.log(f"test/{log_name}", output[output_key])


### PR DESCRIPTION
# What does this PR do?

This PR enables dictionary batches from the datamodule which makes it easier to work with complicated multi-modal datasets. We are feeding the raw batch to the model and we allow users to configure the use in the model sequences.

We also make it backward compatible to the classical `(input, target)` format in computer vision datasets.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] `pytest`
- [ ] `CUDA_VISIBLE_DEVICES=0 python -m mart experiment=CIFAR10_CNN_Adv trainer=gpu trainer.precision=16` reports 70% (21 sec/epoch).
- [ ] `CUDA_VISIBLE_DEVICES=0,1 python -m mart experiment=CIFAR10_CNN_Adv trainer=ddp trainer.precision=16 trainer.devices=2 model.optimizer.lr=0.2 trainer.max_steps=2925 datamodule.ims_per_batch=256 datamodule.world_size=2` reports 70% (14 sec/epoch).

## Before submitting

- [x] The title is **self-explanatory** and the description **concisely** explains the PR
- [x] My **PR does only one thing**, instead of bundling different changes together
- [ ] I list all the **breaking changes** introduced by this pull request
- [x] I have commented my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run pre-commit hooks with `pre-commit run -a` command without errors

## Did you have fun?

Make sure you had fun coding 🙃
